### PR TITLE
Create pull_request_template.md

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,9 +1,14 @@
 [Link to the Jira ticket](https://dsdmoj.atlassian.net/browse/EL-XXX)
 
-What I have done on this ticket:
+Describe what you did and why.
 
+Checklist
 
-Checklist:
- * all tests pass
- * changes have full test coverage/repo has 100% coverage
- * recently rebased on main
+Before you ask people to review this PR:
+
+    Tests and rubocop should be passing
+    Github should not be reporting conflicts; you should have recently run git rebase main.
+    There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
+    The PR description should say what you changed and why, with a link to the JIRA story.
+    You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
+    You should have checked that the commit messages say why the change was made.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,9 @@
+[Link to the Jira ticket](https://dsdmoj.atlassian.net/browse/EL-XXX)
+
+What I have done on this ticket:
+
+
+Checklist:
+ * all tests pass
+ * changes have full test coverage/repo has 100% coverage
+ * recently rebased on main


### PR DESCRIPTION
This is a template for PRs created for the repo. It standardises the format and makes linking the JIRA ticket easier. Other than the link the rest is just a starter we may want to amend/add to these after we have discussed our ways of working.

it currently resides in a hidden .github folder in the repo but ti can be saved elsewhere if anyone prefers it to be more visible e.g in a `/docs` folder for example