### PR TITLE
Spike for slim templates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,13 +74,9 @@ jobs:
       - attach_workspace:
           at: ./
       - run:
-          name: Rubocop checks
+          name: slim-lint checks
           command: |
-            bundle exec rubocop
-      - run:
-          name: erb-lint checks
-          command: |
-            bundle exec erblint --lint-all
+            bundle exec slim-lint app/**/*.slim
 
 workflows:
   build_and_run_specs:

--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,7 @@ group :development, :test do
 end
 
 group :development do
+  gem "slim_lint"
   # Use console on exceptions pages [https://github.com/rails/web-console]
   gem "web-console"
 
@@ -72,3 +73,4 @@ end
 gem "govuk-components"
 gem "govuk_design_system_formbuilder"
 gem "wicked"
+gem "slim-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -271,9 +271,21 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    slim (4.1.0)
+      temple (>= 0.7.6, < 0.9)
+      tilt (>= 2.0.6, < 2.1)
+    slim-rails (3.5.1)
+      actionpack (>= 3.1)
+      railties (>= 3.1)
+      slim (>= 3.0, < 5.0)
+    slim_lint (0.22.1)
+      rubocop (>= 0.78.0)
+      slim (>= 3.0, < 5.0)
     smart_properties (1.17.0)
     strscan (3.0.4)
+    temple (0.8.2)
     thor (1.2.1)
+    tilt (2.0.11)
     timeout (0.3.0)
     tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
@@ -323,6 +335,8 @@ DEPENDENCIES
   rubocop-performance
   selenium-webdriver
   simplecov
+  slim-rails
+  slim_lint
   tzinfo-data
   web-console
   webdrivers

--- a/app/views/pages/home.html.slim
+++ b/app/views/pages/home.html.slim
@@ -1,0 +1,18 @@
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
+    h1 class="govuk-heading-xl">It works! 🎉
+
+    p class="govuk-body"
+      | So long as this page rendered without any errors you're good to go.
+
+    - govuk_summary_list(rows: [\
+        { key: { text: "Rails version" }, value: { text: Rails.version } },
+        { key: { text: "Ruby version" }, value: { text: RUBY_VERSION } },
+        { key: { text: "GOV.UK Frontend" },
+          value: { \
+            text: JSON.parse(File.read(Rails.root.join("package.json"))) \
+          .dig("dependencies", "govuk-frontend") \
+          .tr("^", ""),\
+          },\
+          },\
+          ])


### PR DESCRIPTION
This is an example of how the trivial home page looks like re-written using Slim. This was driven partly by the 'erb-lint' story which this format makes pretty redundant