### PR TITLE
Propshaft assets in test mode

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,12 +77,6 @@ jobs:
           name: Install yarn modules
           command: yarn install
       - run:
-          name: Compile frontend JS modules
-          command: yarn build
-      - run:
-          name: Compile frontend SCSS files
-          command: yarn build:css
-      - run:
           name: Install ruby gems
           command: |
             bundle config set path 'vendor/bundle'
@@ -92,6 +86,9 @@ jobs:
               # Install missing gems
               bundle install
             }
+      - run:
+          name: Compile assets for test run
+          command: bundle exec rake test:prepare
       - save_cache:
           key: laa-estimate-eligibility-{{ checksum "Gemfile.lock" }}-v1-{{ checksum "yarn.lock" }}
           paths:

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ This is a calculator for providers to obtain a quick estimate to decide if a cli
 
 ## Documentation for developers.
 
+The new 'propshaft' asset pipeline (specifically jsbundling-rails and cssbundling-rails gems) has a 'test:prepare'
+task that gets invoked in lots of useful places -
+see https://stackoverflow.com/questions/71262775/how-do-i-ensure-assets-are-present-with-rail-7-cssbundling-rails-jsbundling-ra
+
 ## Dependencies
 
 - Ruby version

--- a/config/application.rb
+++ b/config/application.rb
@@ -12,7 +12,7 @@ require "action_controller/railtie"
 # require "action_text/engine"
 require "action_view/railtie"
 # require "action_cable/engine"
-# require "rails/test_unit/railtie"
+require "rails/test_unit/railtie"
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.


### PR DESCRIPTION
 https://dsdmoj.atlassian.net/browse/EL-259

According to this post https://stackoverflow.com/questions/71262775/how-do-i-ensure-assets-are-present-with-rail-7-cssbundling-rails-jsbundling-ra propshaft is a lot less supportive than previous asset pipelines. However it turns out that disabling the rails 'tests' railtie caused certain hooks to be removed - specifically a silent 'test:prepare' rake task, which when enabled makes the assets up-to-date for a 'rake spec' run