### PR TITLE
EL-282 remove database (from environment files)

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -43,10 +43,10 @@ Rails.application.configure do
   config.active_support.disallowed_deprecation_warnings = []
 
   # Raise an error on page load if there are pending migrations.
-  config.active_record.migration_error = :page_load
+  # config.active_record.migration_error = :page_load
 
   # Highlight code that triggered database queries in logs.
-  config.active_record.verbose_query_logs = true
+  # config.active_record.verbose_query_logs = true
 
   # Raises error for missing translations.
   # config.i18n.raise_on_missing_translations = true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -69,5 +69,5 @@ Rails.application.configure do
   end
 
   # Do not dump schema after migrations.
-  config.active_record.dump_schema_after_migration = false
+  # config.active_record.dump_schema_after_migration = false
 end


### PR DESCRIPTION
The first PR for EL-282 didn't remove the database references from the environment files. This removes them so that tasks like rake assets:precompile work without crashing

[Link to the Jira ticket](https://dsdmoj.atlassian.net/browse/EL-282)