### PR TITLE
Restrict ECR and deploy tasks to main branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -172,7 +172,15 @@ workflows:
           requires:
             - run_specs
             - linters
+          filters:
+            branches:
+              only:
+                - main
       - deploy_staging:
           context: laa-estimate-eligibility-staging
           requires:
             - build_and_push_to_ecr
+          filters:
+            branches:
+              only:
+                - main


### PR DESCRIPTION
Currently we are deploying all builds to ECR and staging - this is slow and is resulting in resource clashes for the staging environment