### PR TITLE
Bugfix: Formatting of monetary values on final results page

### DIFF
--- a/app/views/build_estimates/results.html.erb
+++ b/app/views/build_estimates/results.html.erb
@@ -11,7 +11,7 @@
         <strong>
           &pound;<%= number_with_precision(@form.dig(:result_summary, :overall_result, :income_contribution),
                                            precision: 2,
-                                           separator: ",") %>
+                                           delimiter: ",") %>
         </strong>
         <%= t(".income-contribution") %>
       </li>
@@ -19,7 +19,7 @@
         <strong>
           &pound;<%= number_with_precision(@form.dig(:result_summary, :overall_result, :capital_contribution),
                                            precision: 2,
-                                           separator: ",") %>
+                                           delimiter: ",") %>
         </strong>
         <%= t(".capital-contribution") %>
       </li>

--- a/spec/features/applicant_page_spec.rb
+++ b/spec/features/applicant_page_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe "Applicant Page" do
       click_checkbox("assets-form-assets", "none")
       click_on "Save and continue"
 
-      allow(mock_connection).to receive(:api_result).and_return(result_summary: { overall_result: { income_contribution: 0 } })
+      allow(mock_connection).to receive(:api_result).and_return(result_summary: { overall_result: { income_contribution: 12_345.78 } })
     end
 
     context "when over 60" do
@@ -106,6 +106,7 @@ RSpec.describe "Applicant Page" do
 
         expect(page).to have_content "Summary Page"
         click_on "Submit"
+        expect(page).to have_content "£12,345.78 per month"
       end
     end
 


### PR DESCRIPTION
I didn't spot this when reviewing #33, but there's a very small config bug in a view file, where we're using [number_with_precision](https://apidock.com/rails/ActionView/Helpers/NumberHelper/number_with_precision) to format a decimal value. This was resulting in, e.g., `1234.56`, which should be rendered as `£1,234.56`, instead being rendered as `£1234,56`.

Checklist

Before you ask people to review this PR:

    Tests and rubocop should be passing
    Github should not be reporting conflicts; you should have recently run git rebase main.
    There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
    The PR description should say what you changed and why, with a link to the JIRA story.
    You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
    You should have checked that the commit messages say why the change was made.
