### PR TITLE
Bugfix: update deployment script to fix k8s naming length issue

### DIFF
--- a/bin/uat_deployment
+++ b/bin/uat_deployment
@@ -4,7 +4,7 @@ deploy() {
 #  ECR_ENDPOINT is a CircleCI environment variable
   IMG_REPO="$ECR_ENDPOINT"
 # Convert the branch name into a string that can be turned into a valid URL
-  RELEASE_NAME=$(echo $CIRCLE_BRANCH | tr '[:upper:]' '[:lower:]' | sed 's:^\w*\/::' | tr -s ' _/[]().' '-' | cut -c1-30 | sed 's/-$//')
+  RELEASE_NAME=$(echo $CIRCLE_BRANCH | tr '[:upper:]' '[:lower:]' | sed 's:^\w*\/::' | tr -s ' _/[]().' '-' | cut -c1-20 | sed 's/-$//')
 # Set the deployment host, this will add the prefix of the branch name e.g el-257-deploy-with-circleci or just main
   RELEASE_HOST="$RELEASE_NAME-estimate-financial-eligibility-uat.cloud-platform.service.justice.gov.uk"
 # Set the ingress name, needs release name, namespace and -green suffix


### PR DESCRIPTION
kubernetes has an issue if names are too long. The script needs to cut more of the branch name before using that as the release/ingress name. This changes the script to use only the first 20 characters of the branch name.

Checklist

Before you ask people to review this PR:

    Tests and rubocop should be passing
    Github should not be reporting conflicts; you should have recently run git rebase main.
    There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
    The PR description should say what you changed and why, with a link to the JIRA story.
    You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
    You should have checked that the commit messages say why the change was made.
