### PR TITLE
Update circle to not use specific docker version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,8 +138,7 @@ jobs:
     executor: cloud-platform-executor
     steps:
       - checkout
-      - setup_remote_docker:
-          version: 20.10.7
+      - setup_remote_docker
       - *decrypt_secrets
       - *build_docker_image
       - *push_to_ecr


### PR DESCRIPTION
As per this message in slack
https://mojdt.slack.com/archives/C02D2NEF9CJ/p1665061637638169
This removes the version associated with the build_ecr job which should prevent failures mentioned in the slack message 

Describe what you did and why.

Checklist

Before you ask people to review this PR:

    Tests and rubocop should be passing
    Github should not be reporting conflicts; you should have recently run git rebase main.
    There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
    The PR description should say what you changed and why, with a link to the JIRA story.
    You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
    You should have checked that the commit messages say why the change was made.
