### PR TITLE
EL-380 Add circleci job to delete helm deployments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -172,7 +172,19 @@ jobs:
                           --namespace=${K8S_NAMESPACE} \
                           --values ./helm_deploy/laa-estimate-eligibility/values-staging.yaml \
                           --set image.repository="$ECR_ENDPOINT" \
-                          --set image.tag="${CIRCLE_SHA1}"          
+                          --set image.tag="${CIRCLE_SHA1}"
+
+  delete_uat_branch:
+    executor: cloud-platform-executor
+    steps:
+      - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - *authenticate_k8s
+      - run:
+          name: Delete UAT deployment
+          command: |
+            ./bin/delete_uat_deployment
             
 
 workflows:
@@ -218,6 +230,10 @@ workflows:
           context: laa-estimate-eligibility-uat
           requires:
             - build_and_push_to_ecr
+      - delete_uat_branch:
+          context: laa-estimate-eligibility-uat
+          requires:
+            - deploy_main_uat
       - deploy_staging:
           context: laa-estimate-eligibility-staging
           requires:

--- a/bin/delete_uat_deployment
+++ b/bin/delete_uat_deployment
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+GIT_MESSAGE=$(git log --format=%B -n 1 $CIRCLE_SHA1)
+
+echo "git message is:"
+echo "$GIT_MESSAGE"
+
+if [[ $GIT_MESSAGE == "Merge pull request #"* ]]
+then
+
+  MERGED_BRANCH=$(echo $GIT_MESSAGE | sed -n "s/^.*from ministryofjustice\/\s*\(\S*\).*$/\1/p")
+  UAT_RELEASE="$(echo $MERGED_BRANCH | sed 's:^\w*\/::' | tr -s ' _/[]().' '-' | cut -c1-20 | sed 's/-$//')"
+
+  echo "UAT release name: $UAT_RELEASE"
+
+  UAT_RELEASES=$(helm list --namespace=${K8S_NAMESPACE} --all)
+
+  echo "List all the current UAT releases:"
+  echo "$UAT_RELEASES"
+
+  if [[ $UAT_RELEASES == *"$UAT_RELEASE"* ]]
+  then
+    echo "Deleting UAT release $UAT_RELEASE"
+    helm delete $UAT_RELEASE -namespace=${K8S_NAMESPACE} --purge
+  else
+    echo "UAT release $UAT_RELEASE was not found"
+  fi
+
+else
+  echo "No deployment found for this merged Pull Request"
+fi


### PR DESCRIPTION
[Link to the Jira ticket](https://dsdmoj.atlassian.net/browse/EL-380)

I decided to implement it as a circleci job instead of github action mainly because it requires the ENV_VARS such as K8S_NAMESPACE, K8S_CLUSTER_CERT etc to be set up on Github. We already have these ENV_VARS on circle for managing deployments so it seemed like a bit of duplication before even starting.

Add a new job to circleci to call a script to check if a deployment needs to be deleted
Add a script to check releases and delete the ones associated with a merged PR

Checklist

Before you ask people to review this PR:

    Tests and rubocop should be passing
    Github should not be reporting conflicts; you should have recently run git rebase main.
    There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
    The PR description should say what you changed and why, with a link to the JIRA story.
    You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
    You should have checked that the commit messages say why the change was made.
