### PR TITLE
EL-332 Add delete script and job to circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,6 +143,16 @@ jobs:
       - *build_docker_image
       - *push_to_ecr
 
+  clean_up_ecr:
+    executor: cloud-platform-executor
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Delete old images from ECR repo
+          command: |
+            ./bin/delete_ecr_images
+
   deploy_uat:
     executor: cloud-platform-executor
     steps:
@@ -226,3 +236,12 @@ workflows:
             branches:
               only:
                 - main
+  nightly:
+    triggers:
+      - schedule:
+          cron: "0 4 * * *"
+          filters:
+            branches:
+              only: main
+    jobs:
+      - clean_up_ecr

--- a/bin/delete_ecr_images
+++ b/bin/delete_ecr_images
@@ -1,0 +1,31 @@
+#!/usr/bin/env ruby
+require 'json'
+require 'date'
+
+repo = 'laa-estimate-eligibility/laa-estimate-financial-eligibility-for-legal-aid-ecr'
+delete_if_older_than = 10 # days
+
+puts 'Identifying images to delete'
+json_output = `aws ecr describe-images --repository-name #{repo} --output json`
+images = JSON.parse(json_output)['imageDetails']
+puts "ECR has #{images.count} images"
+
+images_to_delete = []
+images.each do |i|
+  date_pushed = DateTime.strptime(i['imagePushedAt'].to_s, '%s')
+  age_in_days = (DateTime.now - date_pushed).to_i
+  images_to_delete << i if age_in_days > delete_if_older_than
+end
+
+if images_to_delete.empty?
+  puts 'Nothing to delete'
+else
+  puts "Deleting #{images_to_delete.count} images"
+
+  images_to_delete.each_slice(100) do |batch|
+    image_ids = batch.map { |i| "imageDigest=#{i['imageDigest']}" }.join(' ')
+    puts `aws ecr batch-delete-image --repository-name #{repo} --image-ids #{image_ids}`
+  end
+
+  puts 'Done!'
+end


### PR DESCRIPTION
[Link to the Jira ticket](https://dsdmoj.atlassian.net/browse/EL-332)

Added a nightly job to circleci to clean up ECR images older than 10 days. This is pretty much lifted from the Legal Framework PR that does the same thing for that repo. As such I have not implemented a kubernetes cronjob to do this task (as mentioned in the ticket) but used circleci nightly function.

*NOTE*  
The nightly function used by circleci is due to be deprecated by the end of 2022, as such this method will need to be changed to a cronjob/scheduled pipeline/github action at some point, but this will work for now and avoid any cloud platform alerts

https://support.circleci.com/hc/en-us/articles/115015983008-Scheduling-a-Nightly-Build

Checklist

Before you ask people to review this PR:

    Tests and rubocop should be passing
    Github should not be reporting conflicts; you should have recently run git rebase main.
    There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
    The PR description should say what you changed and why, with a link to the JIRA story.
    You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
    You should have checked that the commit messages say why the change was made.
