### PR TITLE
EL-380 bugfix: Remove purge flag as it is now the default for delete commands

### DIFF
--- a/bin/delete_uat_deployment
+++ b/bin/delete_uat_deployment
@@ -21,7 +21,7 @@ then
   if [[ $UAT_RELEASES == *"$UAT_RELEASE"* ]]
   then
     echo "Deleting UAT release $UAT_RELEASE"
-    helm delete $UAT_RELEASE -namespace=${K8S_NAMESPACE} --purge
+    helm delete $UAT_RELEASE -namespace=${K8S_NAMESPACE}
   else
     echo "UAT release $UAT_RELEASE was not found"
   fi


### PR DESCRIPTION
[Link to the Jira ticket](https://dsdmoj.atlassian.net/browse/EL-380)
Use of the --purge flag to delete helm instances is no longer necessary as this is now part of the default helm delete command

Checklist

Before you ask people to review this PR:

    Tests and rubocop should be passing
    Github should not be reporting conflicts; you should have recently run git rebase main.
    There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
    The PR description should say what you changed and why, with a link to the JIRA story.
    You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
    You should have checked that the commit messages say why the change was made.
