### PR TITLE
EL-377: Use a forgiving, nicely formatted money input

### DIFF
--- a/app/forms/assets_form.rb
+++ b/app/forms/assets_form.rb
@@ -12,12 +12,12 @@ class AssetsForm
   ASSETS_ATTRIBUTES = (ASSETS_DECIMAL_ATTRIBUTES.keys + ASSETS_PROPERTY_ATTRIBUTES + [:property_percentage_owned]).freeze
 
   ASSETS_DECIMAL_ATTRIBUTES.each do |asset_type, threshold|
-    attribute asset_type, :decimal
+    attribute asset_type, :gbp
     validates asset_type, numericality: threshold.merge(allow_nil: true), presence: true, if: -> { assets.include?(asset_type.to_s) }
   end
 
-  attribute :property_value, :decimal
-  attribute :property_mortgage, :decimal
+  attribute :property_value, :gbp
+  attribute :property_mortgage, :gbp
   validates :property_value, numericality: { greater_than: 0, allow_nil: true }, presence: true, if: -> { assets.include?("property") }
   validates :property_mortgage, numericality: { greater_than_or_equal_to: 0, allow_nil: true }, presence: true, if: -> { assets.include?("property") }
 

--- a/app/forms/employment_form.rb
+++ b/app/forms/employment_form.rb
@@ -6,7 +6,7 @@ class EmploymentForm
   EMPLOYMENT_ATTRIBUTES = (DECIMAL_ATTRIBUTES + %i[frequency]).freeze
 
   DECIMAL_ATTRIBUTES.each do |attribute|
-    attribute attribute, :decimal
+    attribute attribute, :gbp
     validates attribute, presence: true
   end
 

--- a/app/forms/monthly_income_form.rb
+++ b/app/forms/monthly_income_form.rb
@@ -12,7 +12,7 @@ class MonthlyIncomeForm
   INCOME_ATTRIBUTES = %i[friends_or_family maintenance property_or_lodger pension student_finance other].freeze
 
   INCOME_ATTRIBUTES.each do |attribute|
-    attribute attribute, :decimal
+    attribute attribute, :gbp
     validates attribute,
               numericality: { greater_than: 0, allow_nil: true },
               presence: true,

--- a/app/forms/outgoings_form.rb
+++ b/app/forms/outgoings_form.rb
@@ -12,7 +12,7 @@ class OutgoingsForm
   OUTGOING_ATTRIBUTES = %i[housing_payments].freeze
 
   OUTGOING_ATTRIBUTES.each do |attribute|
-    attribute attribute, :decimal
+    attribute attribute, :gbp
     validates attribute,
               numericality: { greater_than: 0, allow_nil: true },
               presence: true,

--- a/app/forms/property_entry_form.rb
+++ b/app/forms/property_entry_form.rb
@@ -6,10 +6,10 @@ class PropertyEntryForm
 
   attr_accessor :property_owned
 
-  attribute :house_value, :integer
+  attribute :house_value, :gbp
   validates :house_value, numericality: { greater_than: 0, only_integer: true, allow_nil: true }, presence: true
 
-  attribute :mortgage, :integer
+  attribute :mortgage, :gbp
   validates :mortgage,
             numericality: { greater_than: 0, only_integer: true, allow_nil: true },
             presence: { if: -> { property_owned == "with_mortgage" } }

--- a/app/forms/property_entry_form.rb
+++ b/app/forms/property_entry_form.rb
@@ -7,11 +7,11 @@ class PropertyEntryForm
   attr_accessor :property_owned
 
   attribute :house_value, :gbp
-  validates :house_value, numericality: { greater_than: 0, only_integer: true, allow_nil: true }, presence: true
+  validates :house_value, numericality: { greater_than: 0, allow_nil: true }, presence: true
 
   attribute :mortgage, :gbp
   validates :mortgage,
-            numericality: { greater_than: 0, only_integer: true, allow_nil: true },
+            numericality: { greater_than: 0, allow_nil: true },
             presence: { if: -> { property_owned == "with_mortgage" } }
 
   attribute :percentage_owned, :integer

--- a/app/forms/vehicle_finance_form.rb
+++ b/app/forms/vehicle_finance_form.rb
@@ -7,7 +7,7 @@ class VehicleFinanceForm
   attribute :vehicle_pcp, :boolean
   validates :vehicle_pcp, inclusion: { in: [true, false], allow_nil: false }
 
-  attribute :vehicle_finance, :decimal
+  attribute :vehicle_finance, :gbp
   validates :vehicle_finance,
             numericality: { greater_than: 0, allow_nil: true },
             presence: true, if: -> { vehicle_pcp }

--- a/app/forms/vehicle_value_form.rb
+++ b/app/forms/vehicle_value_form.rb
@@ -4,7 +4,7 @@ class VehicleValueForm
 
   VEHICLE_VALUE_ATTRIBUTES = %i[vehicle_value vehicle_in_regular_use].freeze
 
-  attribute :vehicle_value, :decimal
+  attribute :vehicle_value, :gbp
   validates :vehicle_value,
             numericality: { greater_than: 0, allow_nil: true },
             presence: true

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -12,8 +12,8 @@ module ApplicationHelper
 
   def decimal_as_money_string(form, field)
     current_value = form.object.attributes[field.to_s]
-    return current_value.to_i if current_value&.round == current_value && !current_value.nil?
+    precision = current_value&.round == current_value ? 0 : 2
 
-    number_with_precision(current_value, precision: 2, delimiter: ",")
+    number_with_precision(current_value, precision:, delimiter: ",")
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -9,4 +9,11 @@ module ApplicationHelper
                                                          role: "presentation",
                                                          focusable: "false")
   end
+
+  def decimal_as_money_string(form, field)
+    current_value = form.object.attributes[field.to_s]
+    return current_value.to_i if current_value&.round == current_value && !current_value.nil?
+
+    number_with_precision(current_value, precision: 2, delimiter: ",")
+  end
 end

--- a/app/views/shared/_money_input.html.slim
+++ b/app/views/shared/_money_input.html.slim
@@ -1,3 +1,7 @@
-= form.govuk_number_field field, width:,
-        label: { text: label_text },
-        prefix_text: BuildEstimatesHelper::POUND
+= form.govuk_text_field field,
+                        width:,
+                        label: { text: label_text },
+                        prefix_text: BuildEstimatesHelper::POUND,
+                        value: decimal_as_money_string(form, field),
+                        pattern: "[0-9]*",
+                        inputmode: "numeric"

--- a/app/views/shared/_money_input_with_hint.html.slim
+++ b/app/views/shared/_money_input_with_hint.html.slim
@@ -1,5 +1,9 @@
 / when the field has a hint, the label needs to be a larger (more bold) font
-= form.govuk_number_field field, width:,
-        hint: { text: hint_text },
-        label: { text: label_text, size: "m" },
-        prefix_text: BuildEstimatesHelper::POUND
+= form.govuk_text_field field,
+                        width:,
+                        hint: { text: hint_text },
+                        label: { text: label_text, size: "m" },
+                        prefix_text: BuildEstimatesHelper::POUND,
+                        value: decimal_as_money_string(form, field),
+                        pattern: "[0-9]*",
+                        inputmode: "numeric"

--- a/config/initializers/attribute_types.rb
+++ b/config/initializers/attribute_types.rb
@@ -1,0 +1,9 @@
+class Gbp < ActiveModel::Type::Decimal
+  # When a monetary value is provided by a form submission, we are only interested
+  # in the value to 2 decimal places, and discard any more fine detail immediately
+  def cast(value)
+    super(value&.delete(","))&.round(2)
+  end
+end
+
+ActiveModel::Type.register(:gbp, Gbp)

--- a/spec/features/assets_page_spec.rb
+++ b/spec/features/assets_page_spec.rb
@@ -53,7 +53,6 @@ RSpec.describe "Assets Page" do
       fill_in "property-entry-form-mortgage-field", with: 50_000
       fill_in "property-entry-form-percentage-owned-field", with: 100
       click_on "Save and continue"
-
       select_boolean_value("vehicle-form", :vehicle_owned, false)
       click_on "Save and continue"
     end

--- a/spec/features/employment_page_spec.rb
+++ b/spec/features/employment_page_spec.rb
@@ -58,9 +58,9 @@ RSpec.describe "Employment page" do
 
     context "when I provide all required information" do
       before do
-        fill_in "employment-form-gross-income-field", with: 1000
-        fill_in "employment-form-income-tax-field", with: 100
-        fill_in "employment-form-national-insurance-field", with: 50
+        fill_in "employment-form-gross-income-field", with: "5,000"
+        fill_in "employment-form-income-tax-field", with: "1000"
+        fill_in "employment-form-national-insurance-field", with: 50.5
         select "Monthly", from: "employment-form-frequency-field"
       end
 
@@ -68,14 +68,23 @@ RSpec.describe "Employment page" do
         expect(mock_connection).to receive(:create_employment) do |id, params|
           expect(id).to eq estimate_id
           payment = params.dig(0, :payments, 1)
-          expect(payment[:gross]).to eq 1_000
-          expect(payment[:tax]).to eq(-100)
-          expect(payment[:national_insurance]).to eq(-50)
+          expect(payment[:gross]).to eq 5_000
+          expect(payment[:tax]).to eq(-1_000)
+          expect(payment[:national_insurance]).to eq(-50.5)
           expect(payment[:date]).to eq 1.month.ago.to_date
         end
 
         click_on "Save and continue"
         expect(page).not_to have_content employment_page_header
+      end
+
+      it "formats my answers appropriately if I return to the screen" do
+        allow(mock_connection).to receive(:create_employment)
+        click_on "Save and continue"
+        click_on "Back"
+        expect(find("#employment-form-gross-income-field").value).to eq "5,000"
+        expect(find("#employment-form-income-tax-field").value).to eq "1,000"
+        expect(find("#employment-form-national-insurance-field").value).to eq "50.50"
       end
     end
 


### PR DESCRIPTION
[Link to the Jira ticket](https://dsdmoj.atlassian.net/browse/EL-377)

- We allow users to enter "," in their financial amounts, and discard them when we cast them into a model
- We also discard anything beyond 2 decimal places
- When rendering a form input containing a monetary value a user has previously inputted:
  - If the user had previously entered no decimal places, or the value is already rounded to the nearest pound, we don't display pence
  - Otherwise we display pence to 2 decimal places
  - In all cases we show "," thousand separators to improve readability 
- (Also fix a minor bug where we were re-sending the student loan value to CFE even after the student loan checkbox had been unchecked)
