### PR TITLE
Bugfix: Stop us sending student loan values if loan box is unchecked

### DIFF
--- a/app/controllers/flow/monthly_income_handler.rb
+++ b/app/controllers/flow/monthly_income_handler.rb
@@ -16,7 +16,9 @@ module Flow
         # TODO: CFE will raise an error the second time `create_student_loan` is called
         # for a given estimate_id, meaning that submitting the monthly income page
         # twice by using the back button can raise an error
-        cfe_connection.create_student_loan estimate_id, income_form.student_finance
+        if income_form.monthly_incomes.include?("student_finance")
+          cfe_connection.create_student_loan estimate_id, income_form.student_finance
+        end
 
         # TODO: CFE does not understand about _modifying_ previously described
         # regular payments, meaning that submitting the monthly income page

--- a/spec/features/monthly_income_page_spec.rb
+++ b/spec/features/monthly_income_page_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe "Monthly income Page" do
   end
 
   it "moves onto outgoings with no income" do
-    expect(mock_connection).to receive(:create_student_loan).with(estimate_id, nil)
+    expect(mock_connection).not_to receive(:create_student_loan)
     expect(mock_connection)
       .to receive(:create_regular_payments)
 
@@ -60,7 +60,7 @@ RSpec.describe "Monthly income Page" do
   end
 
   it "handles non-student finance values and moves to the next screen" do
-    expect(mock_connection).to receive(:create_student_loan).with(estimate_id, nil)
+    expect(mock_connection).not_to receive(:create_student_loan)
     expect(mock_connection).to receive(:create_regular_payments) do |_estimate_id, model|
       expect(model.friends_or_family).to eq 100
       expect(model.maintenance).to eq 200


### PR DESCRIPTION
Previously you could check 'student loan', enter a value, then uncheck it, and the value you had entered would still be sent. This fixes that.

Before you ask people to review this PR:

    Tests and rubocop should be passing
    Github should not be reporting conflicts; you should have recently run git rebase main.
    There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
    The PR description should say what you changed and why, with a link to the JIRA story.
    You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
    You should have checked that the commit messages say why the change was made.
