### PR TITLE
EL-389 Warn if user enters negative (net) income

### DIFF
--- a/app/forms/employment_form.rb
+++ b/app/forms/employment_form.rb
@@ -10,6 +10,8 @@ class EmploymentForm
     validates attribute, presence: true
   end
 
+  validate :net_income_must_be_positive
+
   attribute :frequency, :string
   validates :frequency, presence: true
 
@@ -18,6 +20,14 @@ class EmploymentForm
   def frequency_options
     FREQUENCY_OPTIONS.map do |key|
       OpenStruct.new(value: key, label: I18n.t("build_estimates.employment.frequency.#{key}"))
+    end
+  end
+
+private
+
+  def net_income_must_be_positive
+    if gross_income.to_i - income_tax.to_i - national_insurance.to_i <= 0
+      errors.add(:gross_income, :net_income_must_be_positive)
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -22,6 +22,7 @@ en:
           attributes:
             gross_income:
               blank: Income cannot be blank
+              net_income_must_be_positive: Net income must be positive, please check
             income_tax:
               blank: Income tax cannot be blank
             national_insurance:

--- a/spec/features/employment_page_spec.rb
+++ b/spec/features/employment_page_spec.rb
@@ -45,6 +45,22 @@ RSpec.describe "Employment page" do
       expect(page).to have_content "Your client's details"
     end
 
+    context "when I enter negative income by mistake" do
+      before do
+        fill_in "employment-form-gross-income-field", with: 100
+        fill_in "employment-form-income-tax-field", with: 100
+        fill_in "employment-form-national-insurance-field", with: 50
+        select "Monthly", from: "employment-form-frequency-field"
+        click_on "Save and continue"
+      end
+
+      it "shows a friendly error message" do
+        within ".govuk-error-summary__list" do
+          expect(page).to have_content("Net income must be positive, please check")
+        end
+      end
+    end
+
     context "when I omit some required information" do
       before do
         click_on "Save and continue"


### PR DESCRIPTION
At the moment, if the user enters a negative net income this is sent to CFE which validates it and returns n (unfriendly) 422 error. This moves the validation onto EFE so the user can be informed.

https://dsdmoj.atlassian.net/browse/EL-389