### PR TITLE
El 383 call cfe once

### DIFF
--- a/app/controllers/build_estimates_controller.rb
+++ b/app/controllers/build_estimates_controller.rb
@@ -34,7 +34,6 @@ class BuildEstimatesController < ApplicationController
     if @form.valid?
       session_data.merge!(@form.attributes)
       estimate = load_estimate
-      handler.save_data(cfe_connection, estimate_id, @form, session_data) if last_step_in_group?(estimate, step)
 
       redirect_to wizard_path next_step_for(estimate, step)
     else

--- a/app/controllers/estimates_controller.rb
+++ b/app/controllers/estimates_controller.rb
@@ -1,22 +1,179 @@
 class EstimatesController < ApplicationController
   def new
-    redirect_to estimate_build_estimates_path cfe_connection.create_assessment_id
+    redirect_to estimate_build_estimates_path SecureRandom.uuid
   end
 
   def create
-    # The last thing to do before retrieving the result is to tell CFE
-    # about the applicant
-    create_applicant
+    cfe_estimate_id = cfe_connection.create_assessment_id
 
-    @model = cfe_connection.api_result(params[:cfe_id])
+    applicant_screen_create cfe_estimate_id, Flow::ApplicantHandler.model(cfe_session_data)
+
+    # dont call below if employment question is no
+    save_employment_data cfe_estimate_id, Flow::EmploymentHandler.model(cfe_session_data)
+    save_monthly_income_data cfe_estimate_id, Flow::MonthlyIncomeHandler.model(cfe_session_data)
+
+    # dont call below if vehicle owned question is no
+    save_vehicle_value_data cfe_estimate_id, Flow::Vehicle::ValueHandler.model(cfe_session_data)
+    save_vehicle_finance_data cfe_estimate_id, Flow::Vehicle::FinanceHandler.model(cfe_session_data)
+    save_assets_data cfe_estimate_id, Flow::AssetHandler.model(cfe_session_data)
+    save_outgoings_data cfe_estimate_id, Flow::OutgoingsHandler.model(cfe_session_data)
+
+    # dont call below if property owned question is no
+    save_property_entry_data cfe_estimate_id, Flow::OutgoingsHandler.model(cfe_session_data)
+
+    create_applicant cfe_estimate_id
+    @model = cfe_connection.api_result(cfe_estimate_id)
 
     render :show
   end
 
-  def create_applicant
-    estimate = Flow::ApplicantHandler.model(session_data(params[:cfe_id]))
-    cfe_connection.create_applicant params[:cfe_id],
+  private
+
+  def applicant_screen_create(estimate_id, estimate)
+    cfe_connection.create_dependants(estimate_id, estimate.dependant_count) if estimate.dependants
+  end
+
+  def save_employment_data(estimate_id, form)
+    puts "--------1--------"
+    return unless form.gross_income.present?
+    puts "--------after return should not see--------"
+
+    # CFE wants to infer frequency of payment from gaps between payments.
+    # So we use our knowledge of frequency to generate three appropriately-spaced,
+    # representative payments, to allow CFE to make that inference
+    employment_data = [
+      {
+        name: "Job",
+        client_id: "ID",
+        payments: Array.new(3) do |index|
+          {
+            gross:(form.gross_income * multiplier(form)).round(2),
+            tax: (-1 * form.income_tax * multiplier(form)).round(2),
+            national_insurance: (-1 * form.national_insurance * multiplier(form)).round(2),
+            client_id: "id-#{index}",
+            date: Date.current - period(form, index),
+            benefits_in_kind: 0,
+            net_employment_income: ((form.gross_income - form.income_tax - form.national_insurance) * multiplier(form)).round(2),
+          }
+        end,
+      },
+    ]
+
+    cfe_connection.create_employment(estimate_id, employment_data)
+  end
+
+
+  def save_monthly_income_data(estimate_id, income_form)
+    if income_form.monthly_incomes.include?("student_finance")
+      cfe_connection.create_student_loan estimate_id, income_form.student_finance
+    end
+
+    cfe_connection.create_regular_payments(estimate_id, income_form, nil)
+  end
+
+  def save_vehicle_value_data (estimate_id, value_form)
+    puts "--------2--------"
+    return unless value_form.vehicle_value.present?
+    puts "--------after return should not see--------"
+
+    cfe_connection.create_vehicle estimate_id, date_of_purchase: Time.zone.today.to_date,
+                                  value: value_form.vehicle_value,
+                                  loan_amount_outstanding: 0,
+                                  in_regular_use: value_form.vehicle_in_regular_use
+  end
+
+  def save_vehicle_finance_data(estimate_id, form)
+    puts "--------3--------"
+    value_form = Flow::Vehicle::ValueHandler.model(cfe_session_data)
+
+    return unless value_form.vehicle_value.present?
+    puts "--------after return should not see--------"
+
+    age_form = Flow::Vehicle::AgeHandler.model(cfe_session_data)
+    date_of_purchase = age_form.vehicle_over_3_years_ago ? 4.years.ago.to_date : 2.years.ago.to_date
+    cfe_connection.create_vehicle estimate_id,
+                                  date_of_purchase:,
+                                  value: value_form.vehicle_value,
+                                  loan_amount_outstanding: form.vehicle_finance.presence,
+                                  in_regular_use: value_form.vehicle_in_regular_use
+  end
+
+  def save_assets_data(estimate_id, form)
+    savings = [form.savings].compact
+    investments = [form.investments].compact
+    cfe_connection.create_capitals estimate_id, savings, investments
+
+    if form.assets.include?("property")
+      property_entry_form = Flow::PropertyEntryHandler.model(cfe_session_data)
+      main_home = {
+        value: property_entry_form.house_value,
+        outstanding_mortgage: property_entry_form.mortgage,
+        percentage_owned: property_entry_form.percentage_owned,
+      }
+      second_property = {
+        value: form.property_value,
+        outstanding_mortgage: form.property_mortgage,
+        percentage_owned: form.property_percentage_owned,
+      }
+      cfe_connection.create_properties(estimate_id, main_home, second_property)
+    end
+  end
+
+  def save_outgoings_data(estimate_id, outgoings_form)
+    income_form = Flow::MonthlyIncomeHandler.model(cfe_session_data)
+
+    cfe_connection.create_regular_payments(estimate_id, income_form, outgoings_form)
+  end
+
+  def save_property_entry_data(estimate_id, _model)
+    puts "--------4--------"
+    property_model = Flow::PropertyEntryHandler.model(cfe_session_data)
+
+    return unless property_model.house_value.present?
+    puts "--------after return should not see--------"
+    main_home = {
+      value: property_model.house_value,
+      outstanding_mortgage: (property_model.mortgage.presence if cfe_session_data["property_owned"] == "with_mortgage") || 0,
+      percentage_owned: property_model.percentage_owned
+    }
+    cfe_connection.create_properties(estimate_id, main_home, nil)
+  end
+
+  def create_applicant cfe_estimate_id
+    estimate = Flow::ApplicantHandler.model(cfe_session_data)
+    cfe_connection.create_applicant cfe_estimate_id,
                                     date_of_birth: estimate.over_60 ? 70.years.ago.to_date : 50.years.ago.to_date,
                                     receives_qualifying_benefit: estimate.passporting
+  end
+
+  # CFE doesn't understand about annual salary or 'total income in the last 3 months',
+  # so for both those use cases we must convert the figures we have into what they would
+  # be if they were paid as regular monthly income
+  def multiplier(form)
+    case form.frequency
+    when "annually"
+      1.0 / 12
+    when "total"
+      1.0 / 3
+    else
+      1
+    end
+  end
+
+  def period(form, index)
+    case form.frequency
+    when "annually", "total", "monthly"
+      index.months
+    when "week"
+      index.weeks
+    when "two_weeks"
+      (index * 2).weeks
+    when "four_weeks"
+      (index * 4).weeks
+    end
+  end
+
+  def cfe_session_data
+    session_data params[:cfe_id]
   end
 end

--- a/app/controllers/estimates_controller.rb
+++ b/app/controllers/estimates_controller.rb
@@ -79,7 +79,7 @@ class EstimatesController < ApplicationController
     cfe_connection.create_vehicle cfe_estimate_id,
                                   date_of_purchase:,
                                   value: value_form.vehicle_value,
-                                  loan_amount_outstanding: form.vehicle_finance.presence,
+                                  loan_amount_outstanding: form.vehicle_pcp ? form.vehicle_finance.presence : 0,
                                   in_regular_use: value_form.vehicle_in_regular_use
   end
 

--- a/app/controllers/flow/applicant_handler.rb
+++ b/app/controllers/flow/applicant_handler.rb
@@ -9,9 +9,9 @@ module Flow
         ApplicantForm.new(params.require(:applicant_form).permit(*ApplicantForm::INTRO_ATTRIBUTES))
       end
 
-      def save_data(cfe_connection, estimate_id, estimate, _session_data)
-        cfe_connection.create_dependants(estimate_id, estimate.dependant_count) if estimate.dependants
-      end
+      # def save_data(cfe_connection, estimate_id, estimate, _session_data)
+      #   cfe_connection.create_dependants(estimate_id, estimate.dependant_count) if estimate.dependants
+      # end
     end
   end
 end

--- a/app/controllers/flow/applicant_handler.rb
+++ b/app/controllers/flow/applicant_handler.rb
@@ -8,10 +8,6 @@ module Flow
       def form(params, _session_data)
         ApplicantForm.new(params.require(:applicant_form).permit(*ApplicantForm::INTRO_ATTRIBUTES))
       end
-
-      # def save_data(cfe_connection, estimate_id, estimate, _session_data)
-      #   cfe_connection.create_dependants(estimate_id, estimate.dependant_count) if estimate.dependants
-      # end
     end
   end
 end

--- a/app/controllers/flow/asset_handler.rb
+++ b/app/controllers/flow/asset_handler.rb
@@ -10,34 +10,6 @@ module Flow
       def form(params, _session_data)
         AssetsForm.new(params.require(:assets_form).permit(*AssetsForm::ASSETS_ATTRIBUTES, assets: []))
       end
-
-      def save_data(cfe_connection, estimate_id, form, session_data)
-        liquid_assets = { savings: form.savings }.select { |asset, _value| form.assets.include? asset.to_s }.map(&:last)
-        illiquid_assets = {
-          investments: form.investments,
-          valuables: form.valuables,
-        }.select { |asset, _value| form.assets.include? asset.to_s }.map(&:last)
-        cfe_connection.create_capitals estimate_id, liquid_assets, illiquid_assets if liquid_assets.any? || illiquid_assets.any?
-
-        if form.assets.include?("property")
-          second_property = {
-            value: form.property_value,
-            outstanding_mortgage: form.property_mortgage,
-            percentage_owned: form.property_percentage_owned,
-          }
-        end
-        property_form = PropertyHandler.model(session_data)
-        if property_form.owned?
-          property_entry_form = PropertyEntryHandler.model(session_data)
-          main_home = {
-            value: property_entry_form.house_value,
-            outstanding_mortgage: (property_entry_form.mortgage if property_form.owned_with_mortgage?) || 0,
-            percentage_owned: property_entry_form.percentage_owned,
-          }
-        end
-
-        cfe_connection.create_properties(estimate_id, main_home, second_property) if main_home.present? || second_property.present?
-      end
     end
   end
 end

--- a/app/controllers/flow/employment_handler.rb
+++ b/app/controllers/flow/employment_handler.rb
@@ -9,60 +9,6 @@ module Flow
         EmploymentForm.new(params.require(:employment_form)
           .permit(*EmploymentForm::EMPLOYMENT_ATTRIBUTES))
       end
-
-      # def save_data(cfe_connection, estimate_id, form, _session_data)
-      #   # CFE wants to infer frequency of payment from gaps between payments.
-      #   # So we use our knowledge of frequency to generate three appropriately-spaced,
-      #   # representative payments, to allow CFE to make that inference
-      #   employment_data = [
-      #     {
-      #       name: "Job",
-      #       client_id: "ID",
-      #       payments: Array.new(3) do |index|
-      #         {
-      #           gross: (form.gross_income * multiplier(form)).round(2),
-      #           tax: (-1 * form.income_tax * multiplier(form)).round(2),
-      #           national_insurance: (-1 * form.national_insurance * multiplier(form)).round(2),
-      #           client_id: "id-#{index}",
-      #           date: Date.current - period(form, index),
-      #           benefits_in_kind: 0,
-      #           net_employment_income: ((form.gross_income - form.income_tax - form.national_insurance) * multiplier(form)).round(2),
-      #         }
-      #       end,
-      #     },
-      #   ]
-      #
-      #   cfe_connection.create_employment(estimate_id, employment_data)
-      # end
-
-    private
-
-      # # CFE doesn't understand about annual salary or 'total income in the last 3 months',
-      # # so for both those use cases we must convert the figures we have into what they would
-      # # be if they were paid as regular monthly income
-      # def multiplier(form)
-      #   case form.frequency
-      #   when "annually"
-      #     1.0 / 12
-      #   when "total"
-      #     1.0 / 3
-      #   else
-      #     1
-      #   end
-      # end
-      #
-      # def period(form, index)
-      #   case form.frequency
-      #   when "annually", "total", "monthly"
-      #     index.months
-      #   when "week"
-      #     index.weeks
-      #   when "two_weeks"
-      #     (index * 2).weeks
-      #   when "four_weeks"
-      #     (index * 4).weeks
-      #   end
-      # end
     end
   end
 end

--- a/app/controllers/flow/employment_handler.rb
+++ b/app/controllers/flow/employment_handler.rb
@@ -10,59 +10,59 @@ module Flow
           .permit(*EmploymentForm::EMPLOYMENT_ATTRIBUTES))
       end
 
-      def save_data(cfe_connection, estimate_id, form, _session_data)
-        # CFE wants to infer frequency of payment from gaps between payments.
-        # So we use our knowledge of frequency to generate three appropriately-spaced,
-        # representative payments, to allow CFE to make that inference
-        employment_data = [
-          {
-            name: "Job",
-            client_id: "ID",
-            payments: Array.new(3) do |index|
-              {
-                gross: (form.gross_income * multiplier(form)).round(2),
-                tax: (-1 * form.income_tax * multiplier(form)).round(2),
-                national_insurance: (-1 * form.national_insurance * multiplier(form)).round(2),
-                client_id: "id-#{index}",
-                date: Date.current - period(form, index),
-                benefits_in_kind: 0,
-                net_employment_income: ((form.gross_income - form.income_tax - form.national_insurance) * multiplier(form)).round(2),
-              }
-            end,
-          },
-        ]
-
-        cfe_connection.create_employment(estimate_id, employment_data)
-      end
+      # def save_data(cfe_connection, estimate_id, form, _session_data)
+      #   # CFE wants to infer frequency of payment from gaps between payments.
+      #   # So we use our knowledge of frequency to generate three appropriately-spaced,
+      #   # representative payments, to allow CFE to make that inference
+      #   employment_data = [
+      #     {
+      #       name: "Job",
+      #       client_id: "ID",
+      #       payments: Array.new(3) do |index|
+      #         {
+      #           gross: (form.gross_income * multiplier(form)).round(2),
+      #           tax: (-1 * form.income_tax * multiplier(form)).round(2),
+      #           national_insurance: (-1 * form.national_insurance * multiplier(form)).round(2),
+      #           client_id: "id-#{index}",
+      #           date: Date.current - period(form, index),
+      #           benefits_in_kind: 0,
+      #           net_employment_income: ((form.gross_income - form.income_tax - form.national_insurance) * multiplier(form)).round(2),
+      #         }
+      #       end,
+      #     },
+      #   ]
+      #
+      #   cfe_connection.create_employment(estimate_id, employment_data)
+      # end
 
     private
 
-      # CFE doesn't understand about annual salary or 'total income in the last 3 months',
-      # so for both those use cases we must convert the figures we have into what they would
-      # be if they were paid as regular monthly income
-      def multiplier(form)
-        case form.frequency
-        when "annually"
-          1.0 / 12
-        when "total"
-          1.0 / 3
-        else
-          1
-        end
-      end
-
-      def period(form, index)
-        case form.frequency
-        when "annually", "total", "monthly"
-          index.months
-        when "week"
-          index.weeks
-        when "two_weeks"
-          (index * 2).weeks
-        when "four_weeks"
-          (index * 4).weeks
-        end
-      end
+      # # CFE doesn't understand about annual salary or 'total income in the last 3 months',
+      # # so for both those use cases we must convert the figures we have into what they would
+      # # be if they were paid as regular monthly income
+      # def multiplier(form)
+      #   case form.frequency
+      #   when "annually"
+      #     1.0 / 12
+      #   when "total"
+      #     1.0 / 3
+      #   else
+      #     1
+      #   end
+      # end
+      #
+      # def period(form, index)
+      #   case form.frequency
+      #   when "annually", "total", "monthly"
+      #     index.months
+      #   when "week"
+      #     index.weeks
+      #   when "two_weeks"
+      #     (index * 2).weeks
+      #   when "four_weeks"
+      #     (index * 4).weeks
+      #   end
+      # end
     end
   end
 end

--- a/app/controllers/flow/monthly_income_handler.rb
+++ b/app/controllers/flow/monthly_income_handler.rb
@@ -11,20 +11,6 @@ module Flow
         MonthlyIncomeForm.new(params.require(:monthly_income_form)
           .permit(*MonthlyIncomeForm::INCOME_ATTRIBUTES, monthly_incomes: []))
       end
-
-      # def save_data(cfe_connection, estimate_id, income_form, _session_data)
-      #   # TODO: CFE will raise an error the second time `create_student_loan` is called
-      #   # for a given estimate_id, meaning that submitting the monthly income page
-      #   # twice by using the back button can raise an error
-      #   if income_form.monthly_incomes.include?("student_finance")
-      #     cfe_connection.create_student_loan estimate_id, income_form.student_finance
-      #   end
-      #
-      #   # TODO: CFE does not understand about _modifying_ previously described
-      #   # regular payments, meaning that submitting the monthly income page
-      #   # twice using the back button can cause inaccurate eligibility assessments
-      #   cfe_connection.create_regular_payments(estimate_id, income_form, nil)
-      # end
     end
   end
 end

--- a/app/controllers/flow/monthly_income_handler.rb
+++ b/app/controllers/flow/monthly_income_handler.rb
@@ -12,19 +12,19 @@ module Flow
           .permit(*MonthlyIncomeForm::INCOME_ATTRIBUTES, monthly_incomes: []))
       end
 
-      def save_data(cfe_connection, estimate_id, income_form, _session_data)
-        # TODO: CFE will raise an error the second time `create_student_loan` is called
-        # for a given estimate_id, meaning that submitting the monthly income page
-        # twice by using the back button can raise an error
-        if income_form.monthly_incomes.include?("student_finance")
-          cfe_connection.create_student_loan estimate_id, income_form.student_finance
-        end
-
-        # TODO: CFE does not understand about _modifying_ previously described
-        # regular payments, meaning that submitting the monthly income page
-        # twice using the back button can cause inaccurate eligibility assessments
-        cfe_connection.create_regular_payments(estimate_id, income_form, nil)
-      end
+      # def save_data(cfe_connection, estimate_id, income_form, _session_data)
+      #   # TODO: CFE will raise an error the second time `create_student_loan` is called
+      #   # for a given estimate_id, meaning that submitting the monthly income page
+      #   # twice by using the back button can raise an error
+      #   if income_form.monthly_incomes.include?("student_finance")
+      #     cfe_connection.create_student_loan estimate_id, income_form.student_finance
+      #   end
+      #
+      #   # TODO: CFE does not understand about _modifying_ previously described
+      #   # regular payments, meaning that submitting the monthly income page
+      #   # twice using the back button can cause inaccurate eligibility assessments
+      #   cfe_connection.create_regular_payments(estimate_id, income_form, nil)
+      # end
     end
   end
 end

--- a/app/controllers/flow/outgoings_handler.rb
+++ b/app/controllers/flow/outgoings_handler.rb
@@ -11,11 +11,11 @@ module Flow
         OutgoingsForm.new(params.require(:outgoings_form).permit(*OutgoingsForm::OUTGOING_ATTRIBUTES, outgoings: []))
       end
 
-      def save_data(cfe_connection, estimate_id, outgoings_form, session_data)
-        income_form = MonthlyIncomeHandler.model(session_data)
-
-        cfe_connection.create_regular_payments(estimate_id, income_form, outgoings_form)
-      end
+      # def save_data(cfe_connection, estimate_id, outgoings_form, session_data)
+      #   income_form = MonthlyIncomeHandler.model(session_data)
+      #
+      #   cfe_connection.create_regular_payments(estimate_id, income_form, outgoings_form)
+      # end
     end
   end
 end

--- a/app/controllers/flow/outgoings_handler.rb
+++ b/app/controllers/flow/outgoings_handler.rb
@@ -10,12 +10,6 @@ module Flow
       def form(params, _session_data)
         OutgoingsForm.new(params.require(:outgoings_form).permit(*OutgoingsForm::OUTGOING_ATTRIBUTES, outgoings: []))
       end
-
-      # def save_data(cfe_connection, estimate_id, outgoings_form, session_data)
-      #   income_form = MonthlyIncomeHandler.model(session_data)
-      #
-      #   cfe_connection.create_regular_payments(estimate_id, income_form, outgoings_form)
-      # end
     end
   end
 end

--- a/app/controllers/flow/property_entry_handler.rb
+++ b/app/controllers/flow/property_entry_handler.rb
@@ -12,10 +12,6 @@ module Flow
           model.property_owned = session_data["property_owned"]
         end
       end
-
-      # we can't call CFE here, as we're going to call it later after
-      # the assets screen has been filled in
-      def save_data(cfe_connection, estimate_id, estimate, _session_data); end
     end
   end
 end

--- a/app/controllers/flow/property_handler.rb
+++ b/app/controllers/flow/property_handler.rb
@@ -12,7 +12,7 @@ module Flow
       end
 
       # Will be called when no property owned
-      def save_data(cfe_connection, estimate_id, estimate, _session_data); end
+      # def save_data(cfe_connection, estimate_id, estimate, _session_data); end
     end
   end
 end

--- a/app/controllers/flow/property_handler.rb
+++ b/app/controllers/flow/property_handler.rb
@@ -10,9 +10,6 @@ module Flow
       def form(params, _session_data)
         PropertyForm.new(params.require(:property_form).permit(:property_owned))
       end
-
-      # Will be called when no property owned
-      # def save_data(cfe_connection, estimate_id, estimate, _session_data); end
     end
   end
 end

--- a/app/controllers/flow/vehicle/finance_handler.rb
+++ b/app/controllers/flow/vehicle/finance_handler.rb
@@ -9,17 +9,6 @@ module Flow
         def form(params, _session_data)
           VehicleFinanceForm.new(params.require(:vehicle_finance_form).permit(*VehicleFinanceForm::VEHICLE_FINANCE_ATTRIBUTES))
         end
-
-        # def save_data(cfe_connection, estimate_id, form, session_data)
-        #   age_form = Vehicle::AgeHandler.model(session_data)
-        #   date_of_purchase = age_form.vehicle_over_3_years_ago ? 4.years.ago.to_date : 2.years.ago.to_date
-        #   value_form = Vehicle::ValueHandler.model(session_data)
-        #   cfe_connection.create_vehicle estimate_id,
-        #                                 date_of_purchase:,
-        #                                 value: value_form.vehicle_value,
-        #                                 loan_amount_outstanding: form.vehicle_pcp ? form.vehicle_finance.presence : 0,
-        #                                 in_regular_use: value_form.vehicle_in_regular_use
-        # end
       end
     end
   end

--- a/app/controllers/flow/vehicle/finance_handler.rb
+++ b/app/controllers/flow/vehicle/finance_handler.rb
@@ -10,16 +10,16 @@ module Flow
           VehicleFinanceForm.new(params.require(:vehicle_finance_form).permit(*VehicleFinanceForm::VEHICLE_FINANCE_ATTRIBUTES))
         end
 
-        def save_data(cfe_connection, estimate_id, form, session_data)
-          age_form = Vehicle::AgeHandler.model(session_data)
-          date_of_purchase = age_form.vehicle_over_3_years_ago ? 4.years.ago.to_date : 2.years.ago.to_date
-          value_form = Vehicle::ValueHandler.model(session_data)
-          cfe_connection.create_vehicle estimate_id,
-                                        date_of_purchase:,
-                                        value: value_form.vehicle_value,
-                                        loan_amount_outstanding: form.vehicle_pcp ? form.vehicle_finance.presence : 0,
-                                        in_regular_use: value_form.vehicle_in_regular_use
-        end
+        # def save_data(cfe_connection, estimate_id, form, session_data)
+        #   age_form = Vehicle::AgeHandler.model(session_data)
+        #   date_of_purchase = age_form.vehicle_over_3_years_ago ? 4.years.ago.to_date : 2.years.ago.to_date
+        #   value_form = Vehicle::ValueHandler.model(session_data)
+        #   cfe_connection.create_vehicle estimate_id,
+        #                                 date_of_purchase:,
+        #                                 value: value_form.vehicle_value,
+        #                                 loan_amount_outstanding: form.vehicle_pcp ? form.vehicle_finance.presence : 0,
+        #                                 in_regular_use: value_form.vehicle_in_regular_use
+        # end
       end
     end
   end

--- a/app/controllers/flow/vehicle/owned_handler.rb
+++ b/app/controllers/flow/vehicle/owned_handler.rb
@@ -11,7 +11,7 @@ module Flow
         end
 
         # called when 'no vehicle' selected - nothing to do
-        def save_data(cfe_connection, estimate_id, estimate, _session_data); end
+        # def save_data(cfe_connection, estimate_id, estimate, _session_data); end
       end
     end
   end

--- a/app/controllers/flow/vehicle/owned_handler.rb
+++ b/app/controllers/flow/vehicle/owned_handler.rb
@@ -9,9 +9,6 @@ module Flow
         def form(params, _session_data)
           VehicleForm.new params.require(:vehicle_form).permit(*VehicleForm::VEHICLE_ATTRIBUTES)
         end
-
-        # called when 'no vehicle' selected - nothing to do
-        # def save_data(cfe_connection, estimate_id, estimate, _session_data); end
       end
     end
   end

--- a/app/controllers/flow/vehicle/value_handler.rb
+++ b/app/controllers/flow/vehicle/value_handler.rb
@@ -10,12 +10,12 @@ module Flow
           VehicleValueForm.new(params.require(:vehicle_value_form).permit(*VehicleValueForm::VEHICLE_VALUE_ATTRIBUTES))
         end
 
-        def save_data(cfe_connection, estimate_id, value_form, _session_data)
-          cfe_connection.create_vehicle estimate_id, date_of_purchase: Time.zone.today.to_date,
-                                                     value: value_form.vehicle_value,
-                                                     loan_amount_outstanding: 0,
-                                                     in_regular_use: value_form.vehicle_in_regular_use
-        end
+        # def save_data(cfe_connection, estimate_id, value_form, _session_data)
+        #   cfe_connection.create_vehicle estimate_id, date_of_purchase: Time.zone.today.to_date,
+        #                                              value: value_form.vehicle_value,
+        #                                              loan_amount_outstanding: 0,
+        #                                              in_regular_use: value_form.vehicle_in_regular_use
+        # end
       end
     end
   end

--- a/app/controllers/flow/vehicle/value_handler.rb
+++ b/app/controllers/flow/vehicle/value_handler.rb
@@ -9,13 +9,6 @@ module Flow
         def form(params, _session_data)
           VehicleValueForm.new(params.require(:vehicle_value_form).permit(*VehicleValueForm::VEHICLE_VALUE_ATTRIBUTES))
         end
-
-        # def save_data(cfe_connection, estimate_id, value_form, _session_data)
-        #   cfe_connection.create_vehicle estimate_id, date_of_purchase: Time.zone.today.to_date,
-        #                                              value: value_form.vehicle_value,
-        #                                              loan_amount_outstanding: 0,
-        #                                              in_regular_use: value_form.vehicle_in_regular_use
-        # end
       end
     end
   end

--- a/spec/controllers/estimates_controller_spec.rb
+++ b/spec/controllers/estimates_controller_spec.rb
@@ -1,0 +1,29 @@
+# require 'rails_helper'
+#
+# RSpec.describe EstimatesController  type: :controller do
+#
+#
+#   # expect(mock_connection).to receive(:create_employment) do |_id, params|
+#   #   payment = params.dig(0, :payments, 1)
+#   #   expect(payment[:gross]).to eq 1_000
+#   #   expect(payment[:date]).to eq 2.weeks.ago.to_date
+#   # end
+#   #
+#   # it "persists my answers to CFE and moves me on to the next question" do
+#   #   expect(mock_connection).to receive(:create_employment) do |id, params|
+#   #     expect(id).to eq estimate_id
+#   #     payment = params.dig(0, :payments, 1)
+#   #     expect(payment[:gross]).to eq 1_000
+#   #     expect(payment[:tax]).to eq(-100)
+#   #     expect(payment[:national_insurance]).to eq(-50)
+#   #     expect(payment[:date]).to eq 1.month.ago.to_date
+#   #   end
+#   #
+#   #   click_on "Save and continue"
+#   #   expect(page).not_to have_content employment_page_header
+#   # end
+# end
+
+
+
+

--- a/spec/controllers/estimates_controller_spec.rb
+++ b/spec/controllers/estimates_controller_spec.rb
@@ -23,7 +23,3 @@
 #   #   expect(page).not_to have_content employment_page_header
 #   # end
 # end
-
-
-
-

--- a/spec/features/applicant_page_spec.rb
+++ b/spec/features/applicant_page_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe "Applicant Page" do
     end
 
     it "submits 1 dependant" do
-      expect(mock_connection).to receive(:create_dependants).with(estimate_id, 1)
+      # expect(mock_connection).to receive(:create_dependants).with(estimate_id, 1)
       fill_in "applicant-form-dependant-count-field", with: "1"
       click_on "Save and continue"
       expect(page).to have_content income_header
@@ -109,9 +109,10 @@ RSpec.describe "Applicant Page" do
     end
 
     before do
-      allow(CfeConnection).to receive(:connection).and_return(mock_connection)
+      # allow(CfeConnection).to receive(:connection).and_return(mock_connection)
       allow(mock_connection).to receive(:create_proceeding_type)
       visit_applicant_page
+      visit "/estimates/new"
 
       select_applicant_boolean(:over_60, over_60)
       select_applicant_boolean(:dependants, false)
@@ -135,9 +136,9 @@ RSpec.describe "Applicant Page" do
       let(:date_of_birth) { (Time.zone.today - 70.years).to_date }
 
       it "sets age to 70" do
-        expect(mock_connection).to receive(:create_applicant)
-                                     .with(estimate_id, date_of_birth:,
-                                                        receives_qualifying_benefit: true)
+        # expect(mock_connection).to receive(:create_applicant)
+        #                              .with(estimate_id, date_of_birth:,
+        #                                                 receives_qualifying_benefit: true)
 
         expect(page).to have_content "Summary Page"
         click_on "Submit"
@@ -150,9 +151,9 @@ RSpec.describe "Applicant Page" do
       let(:date_of_birth) { (Time.zone.today - 50.years).to_date }
 
       it "sets age to 50" do
-        expect(mock_connection).to receive(:create_applicant)
-                                     .with(estimate_id, date_of_birth:,
-                                                        receives_qualifying_benefit: true)
+        # expect(mock_connection).to receive(:create_applicant)
+        #                              .with(estimate_id, date_of_birth:,
+        #                                                 receives_qualifying_benefit: true)
         expect(page).to have_content "Summary Page"
         click_on "Submit"
       end

--- a/spec/features/applicant_page_spec.rb
+++ b/spec/features/applicant_page_spec.rb
@@ -5,12 +5,12 @@ RSpec.describe "Applicant Page" do
   let(:property_header) { "Does your client own the home they live in?" }
   let(:applicant_header) { "About your client" }
   let(:estimate_id) { SecureRandom.uuid }
-  let(:mock_connection) { instance_double(CfeConnection, create_assessment_id: estimate_id) }
+  # let(:mock_connection) { instance_double(CfeConnection, create_assessment_id: estimate_id) }
 
   describe "errors" do
     before do
-      allow(CfeConnection).to receive(:connection).and_return(mock_connection)
-      allow(mock_connection).to receive(:create_proceeding_type)
+      # allow(CfeConnection).to receive(:connection).and_return(mock_connection)
+      # allow(mock_connection).to receive(:create_proceeding_type)
       visit_applicant_page
 
       %i[over_60 dependants partner passporting employed].reject { |f| f == field }.each do |f|
@@ -76,8 +76,8 @@ RSpec.describe "Applicant Page" do
 
   describe "dependants field" do
     before do
-      allow(CfeConnection).to receive(:connection).and_return(mock_connection)
-      allow(mock_connection).to receive(:create_proceeding_type)
+      # allow(CfeConnection).to receive(:connection).and_return(mock_connection)
+      # allow(mock_connection).to receive(:create_proceeding_type)
       visit_applicant_page
 
       select_applicant_boolean(:over_60, false)
@@ -110,9 +110,9 @@ RSpec.describe "Applicant Page" do
 
     before do
       # allow(CfeConnection).to receive(:connection).and_return(mock_connection)
-      allow(mock_connection).to receive(:create_proceeding_type)
+      # allow(mock_connection).to receive(:create_proceeding_type)
       visit_applicant_page
-      visit "/estimates/new"
+      # visit "/estimates/new"
 
       select_applicant_boolean(:over_60, over_60)
       select_applicant_boolean(:dependants, false)
@@ -128,7 +128,7 @@ RSpec.describe "Applicant Page" do
       click_checkbox("assets-form-assets", "none")
       click_on "Save and continue"
 
-      allow(mock_connection).to receive(:api_result).and_return(calculation_result)
+      # allow(mock_connection).to receive(:api_result).and_return(calculation_result)
     end
 
     context "when over 60" do

--- a/spec/features/assets_page_spec.rb
+++ b/spec/features/assets_page_spec.rb
@@ -3,10 +3,10 @@ require "rails_helper"
 RSpec.describe "Assets Page" do
   let(:assets_header) { "Which assets does your client have?" }
   let(:estimate_id) { SecureRandom.uuid }
-  let(:mock_connection) { instance_double(CfeConnection, create_assessment_id: estimate_id, create_proceeding_type: nil) }
+  # let(:mock_connection) { instance_double(CfeConnection, create_assessment_id: estimate_id, create_proceeding_type: nil) }
 
   before do
-    allow(CfeConnection).to receive(:connection).and_return(mock_connection)
+    # allow(CfeConnection).to receive(:connection).and_return(mock_connection)
     visit_applicant_page
 
     select_applicant_boolean(:over_60, false)
@@ -31,9 +31,9 @@ RSpec.describe "Assets Page" do
     end
 
     it "can submit second property" do
-      expect(mock_connection)
-        .to receive(:create_properties)
-             .with(estimate_id, nil, { outstanding_mortgage: 50_000, percentage_owned: 50, value: 100_000 })
+      # expect(mock_connection)
+      #   .to receive(:create_properties)
+      #        .with(estimate_id, nil, { outstanding_mortgage: 50_000, percentage_owned: 50, value: 100_000 })
       click_checkbox("assets-form-assets", "property")
       fill_in "assets-form-property-value-field", with: "100_000"
       fill_in "assets-form-property-mortgage-field", with: "50_000"
@@ -45,9 +45,9 @@ RSpec.describe "Assets Page" do
   end
 
   context "with a mortgage" do
-    let(:calculation_result) do
-      CalculationResult.new(result_summary: { overall_result: { result: "contribution_required", income_contribution: 12_345.78 } })
-    end
+    # let(:calculation_result) do
+    #   CalculationResult.new(result_summary: { overall_result: { result: "contribution_required", income_contribution: 12_345.78 } })
+    # end
 
     before do
       click_checkbox("property-form-property-owned", "with_mortgage")
@@ -74,11 +74,11 @@ RSpec.describe "Assets Page" do
     end
 
     it "can submit second property" do
-      expect(mock_connection)
-        .to receive(:create_properties)
-          .with(estimate_id,
-                { outstanding_mortgage: 50_000, percentage_owned: 100, value: 100_000 },
-                { outstanding_mortgage: 40_000, percentage_owned: 50, value: 80_000 })
+      # expect(mock_connection)
+      #   .to receive(:create_properties)
+      #     .with(estimate_id,
+      #           { outstanding_mortgage: 50_000, percentage_owned: 100, value: 100_000 },
+      #           { outstanding_mortgage: 40_000, percentage_owned: 50, value: 80_000 })
 
       click_checkbox("assets-form-assets", "property")
       fill_in "assets-form-property-value-field", with: "80_000"
@@ -90,12 +90,12 @@ RSpec.describe "Assets Page" do
     end
 
     it "can submit non-zero savings and investments" do
-      expect(mock_connection)
-        .to receive(:create_properties)
-              .with(estimate_id,
-                    { outstanding_mortgage: 50_000, percentage_owned: 100, value: 100_000 },
-                    nil)
-      expect(mock_connection).to receive(:create_capitals).with(estimate_id, [100], [500, 1000])
+      # expect(mock_connection)
+      #   .to receive(:create_properties)
+      #         .with(estimate_id,
+      #               { outstanding_mortgage: 50_000, percentage_owned: 100, value: 100_000 },
+      #               nil)
+      # expect(mock_connection).to receive(:create_capitals).with(estimate_id, [100], [500, 1000])
       click_checkbox("assets-form-assets", "savings")
       fill_in "assets-form-savings-field", with: "100"
 
@@ -111,9 +111,9 @@ RSpec.describe "Assets Page" do
     end
 
     it "can fill in the assets questions and get to results" do
-      allow(mock_connection).to receive(:create_properties)
-      allow(mock_connection).to receive(:create_applicant)
-      allow(mock_connection).to receive(:api_result).and_return(calculation_result)
+      # allow(mock_connection).to receive(:create_properties)
+      # allow(mock_connection).to receive(:create_applicant)
+      # allow(mock_connection).to receive(:api_result).and_return(calculation_result)
 
       click_checkbox("assets-form-assets", "none")
       click_on "Save and continue"

--- a/spec/features/employment_page_spec.rb
+++ b/spec/features/employment_page_spec.rb
@@ -3,11 +3,11 @@ require "rails_helper"
 RSpec.describe "Employment page" do
   let(:employment_page_header) { "Add your client's salary breakdown" }
   let(:estimate_id) { SecureRandom.uuid }
-  let(:mock_connection) { instance_double(CfeConnection, create_assessment_id: estimate_id) }
+  # let(:mock_connection) { instance_double(CfeConnection, create_assessment_id: estimate_id) }
 
   before do
-    allow(CfeConnection).to receive(:connection).and_return(mock_connection)
-    allow(mock_connection).to receive(:create_proceeding_type)
+    # allow(CfeConnection).to receive(:connection).and_return(mock_connection)
+    # allow(mock_connection).to receive(:create_proceeding_type)
     visit_applicant_page
   end
 
@@ -80,22 +80,13 @@ RSpec.describe "Employment page" do
         select "Monthly", from: "employment-form-frequency-field"
       end
 
-      it "persists my answers to CFE and moves me on to the next question" do
-        expect(mock_connection).to receive(:create_employment) do |id, params|
-          expect(id).to eq estimate_id
-          payment = params.dig(0, :payments, 1)
-          expect(payment[:gross]).to eq 5_000
-          expect(payment[:tax]).to eq(-1_000)
-          expect(payment[:national_insurance]).to eq(-50.5)
-          expect(payment[:date]).to eq 1.month.ago.to_date
-        end
-
+      it "moves me on to the next question" do
         click_on "Save and continue"
         expect(page).not_to have_content employment_page_header
       end
 
       it "formats my answers appropriately if I return to the screen" do
-        allow(mock_connection).to receive(:create_employment)
+        # allow(mock_connection).to receive(:create_employment)
         click_on "Save and continue"
         click_on "Back"
         expect(find("#employment-form-gross-income-field").value).to eq "5,000"
@@ -112,51 +103,26 @@ RSpec.describe "Employment page" do
       end
 
       it "handles 3-month total" do
-        expect(mock_connection).to receive(:create_employment) do |_id, params|
-          payment = params.dig(0, :payments, 1)
-          expect(payment[:gross]).to eq (1_000 / 3.0).round(2)
-          expect(payment[:date]).to eq 1.month.ago.to_date
-        end
         select "Total in last 3 months", from: "employment-form-frequency-field"
         click_on "Save and continue"
       end
 
       it "handles 1 week" do
-        expect(mock_connection).to receive(:create_employment) do |_id, params|
-          payment = params.dig(0, :payments, 1)
-          expect(payment[:gross]).to eq 1_000
-          expect(payment[:date]).to eq 1.week.ago.to_date
-        end
         select "Every week", from: "employment-form-frequency-field"
         click_on "Save and continue"
       end
 
       it "handles two weeks" do
-        expect(mock_connection).to receive(:create_employment) do |_id, params|
-          payment = params.dig(0, :payments, 1)
-          expect(payment[:gross]).to eq 1_000
-          expect(payment[:date]).to eq 2.weeks.ago.to_date
-        end
         select "Every two weeks", from: "employment-form-frequency-field"
         click_on "Save and continue"
       end
 
       it "handles four weeks" do
-        expect(mock_connection).to receive(:create_employment) do |_id, params|
-          payment = params.dig(0, :payments, 1)
-          expect(payment[:gross]).to eq 1_000
-          expect(payment[:date]).to eq 4.weeks.ago.to_date
-        end
         select "Every four weeks", from: "employment-form-frequency-field"
         click_on "Save and continue"
       end
 
       it "handles annually" do
-        expect(mock_connection).to receive(:create_employment) do |_id, params|
-          payment = params.dig(0, :payments, 1)
-          expect(payment[:gross]).to eq (1_000 / 12.0).round(2)
-          expect(payment[:date]).to eq 1.month.ago.to_date
-        end
         select "Annually", from: "employment-form-frequency-field"
         click_on "Save and continue"
       end

--- a/spec/features/monthly_income_page_spec.rb
+++ b/spec/features/monthly_income_page_spec.rb
@@ -4,11 +4,8 @@ RSpec.describe "Monthly income Page" do
   let(:income_header) { "What other income does your client receive?" }
   let(:outgoings_header) { "What are your client's monthly outgoings and deductions?" }
   let(:estimate_id) { SecureRandom.uuid }
-  let(:mock_connection) { instance_double(CfeConnection, create_assessment_id: estimate_id) }
 
   before do
-    allow(CfeConnection).to receive(:connection).and_return(mock_connection)
-    allow(mock_connection).to receive(:create_proceeding_type)
     visit_applicant_page
 
     select_applicant_boolean(:over_60, false)
@@ -41,9 +38,9 @@ RSpec.describe "Monthly income Page" do
   end
 
   it "moves onto outgoings with no income" do
-    expect(mock_connection).not_to receive(:create_student_loan)
-    expect(mock_connection)
-      .to receive(:create_regular_payments)
+    # expect(mock_connection).not_to receive(:create_student_loan)
+    # expect(mock_connection)
+    #   .to receive(:create_regular_payments)
 
     click_checkbox("monthly-income-form-monthly-incomes", "none")
     click_on "Save and continue"
@@ -51,9 +48,9 @@ RSpec.describe "Monthly income Page" do
   end
 
   it "handles student finance" do
-    expect(mock_connection).to receive(:create_student_loan).with(estimate_id, 100)
-    expect(mock_connection)
-      .to receive(:create_regular_payments)
+    # expect(mock_connection).to receive(:create_student_loan).with(estimate_id, 100)
+    # expect(mock_connection)
+    #   .to receive(:create_regular_payments)
 
     click_checkbox("monthly-income-form-monthly-incomes", "student_finance")
     fill_in "monthly-income-form-student-finance-field", with: "100"
@@ -62,14 +59,14 @@ RSpec.describe "Monthly income Page" do
   end
 
   it "handles non-student finance values and moves to the next screen" do
-    expect(mock_connection).not_to receive(:create_student_loan)
-    expect(mock_connection).to receive(:create_regular_payments) do |_estimate_id, model|
-      expect(model.friends_or_family).to eq 100
-      expect(model.maintenance).to eq 200
-      expect(model.property_or_lodger).to eq 300
-      expect(model.pension).to eq 400
-      expect(model.other).to eq 500
-    end
+    # expect(mock_connection).not_to receive(:create_student_loan)
+    # expect(mock_connection).to receive(:create_regular_payments) do |_estimate_id, model|
+    #   expect(model.friends_or_family).to eq 100
+    #   expect(model.maintenance).to eq 200
+    #   expect(model.property_or_lodger).to eq 300
+    #   expect(model.pension).to eq 400
+    #   expect(model.other).to eq 500
+    # end
 
     click_checkbox("monthly-income-form-monthly-incomes", "friends_or_family")
     fill_in "monthly-income-form-friends-or-family-field", with: "100"

--- a/spec/features/property_page_spec.rb
+++ b/spec/features/property_page_spec.rb
@@ -5,11 +5,8 @@ RSpec.describe "Property Page" do
   let(:property_header) { "Does your client own the home they live in?" }
   let(:vehicle_header) { "Does your client own a vehicle?" }
   let(:estimate_id) { SecureRandom.uuid }
-  let(:mock_connection) { instance_double(CfeConnection, create_assessment_id: estimate_id) }
 
   before do
-    allow(CfeConnection).to receive(:connection).and_return(mock_connection)
-    allow(mock_connection).to receive(:create_proceeding_type)
     visit_applicant_page
 
     select_applicant_boolean(:over_60, false)
@@ -33,7 +30,7 @@ RSpec.describe "Property Page" do
   end
 
   it "can set property to mortage owned" do
-    expect(mock_connection).to receive(:create_properties)
+    # expect(mock_connection).to receive(:create_properties)
 
     click_checkbox("property-form-property-owned", "with_mortgage")
     click_on "Save and continue"
@@ -53,7 +50,7 @@ RSpec.describe "Property Page" do
   end
 
   it "applies validation on the property entry form" do
-    allow(mock_connection).to receive(:create_properties)
+    # allow(mock_connection).to receive(:create_properties)
 
     click_checkbox("property-form-property-owned", "with_mortgage")
     click_on "Save and continue"

--- a/spec/features/result_page_spec.rb
+++ b/spec/features/result_page_spec.rb
@@ -2,12 +2,12 @@ require "rails_helper"
 
 RSpec.describe "Results Page" do
   let(:estimate_id) { "123" }
-  let(:mock_connection) do
-    instance_double(CfeConnection, api_result: CalculationResult.new(payload), create_applicant: nil)
-  end
+  # let(:mock_connection) do
+  #   instance_double(CfeConnection, api_result: CalculationResult.new(payload), create_applicant: nil)
+  # end
 
   before do
-    allow(CfeConnection).to receive(:connection).and_return(mock_connection)
+    # allow(CfeConnection).to receive(:connection).and_return(mock_connection)
     visit "/estimates/#{estimate_id}/build_estimates/summary"
     click_on "Submit"
   end

--- a/spec/features/vehicle_page_spec.rb
+++ b/spec/features/vehicle_page_spec.rb
@@ -8,11 +8,8 @@ RSpec.describe "Vehicle Page" do
 
   context "without property" do
     let(:estimate_id) { SecureRandom.uuid }
-    let(:mock_connection) { instance_double(CfeConnection, create_assessment_id: estimate_id, create_proceeding_type: nil) }
 
     before do
-      allow(CfeConnection).to receive(:connection).and_return(mock_connection)
-
       visit_applicant_page
       select_applicant_boolean(:over_60, false)
       select_applicant_boolean(:dependants, false)
@@ -89,11 +86,11 @@ RSpec.describe "Vehicle Page" do
 
           context "when purchased 3 years ago" do
             it "uses 4 years old" do
-              expect(mock_connection).to receive(:create_vehicle).with(estimate_id,
-                                                                       date_of_purchase: 4.years.ago.to_date,
-                                                                       value: vehicle_value,
-                                                                       loan_amount_outstanding: loan_amount,
-                                                                       in_regular_use: true)
+              # expect(mock_connection).to receive(:create_vehicle).with(estimate_id,
+              #                                                          date_of_purchase: 4.years.ago.to_date,
+              #                                                          value: vehicle_value,
+              #                                                          loan_amount_outstanding: loan_amount,
+              #                                                          in_regular_use: true)
 
               select_boolean_value("vehicle-age-form", :vehicle_over_3_years_ago, true)
               click_on "Save and continue"
@@ -110,11 +107,11 @@ RSpec.describe "Vehicle Page" do
             end
 
             it "uses 2 years old" do
-              expect(mock_connection).to receive(:create_vehicle).with(estimate_id,
-                                                                       date_of_purchase: 2.years.ago.to_date,
-                                                                       value: vehicle_value,
-                                                                       loan_amount_outstanding: loan_amount,
-                                                                       in_regular_use: true)
+              # expect(mock_connection).to receive(:create_vehicle).with(estimate_id,
+              #                                                          date_of_purchase: 2.years.ago.to_date,
+              #                                                          value: vehicle_value,
+              #                                                          loan_amount_outstanding: loan_amount,
+              #                                                          in_regular_use: true)
 
               select_boolean_value("vehicle-finance-form", :vehicle_pcp, true)
               fill_in "vehicle-finance-form-vehicle-finance-field", with: loan_amount
@@ -145,34 +142,34 @@ RSpec.describe "Vehicle Page" do
 
               it "can be corrected" do
                 fill_in "vehicle-finance-form-vehicle-finance-field", with: loan_amount
-                expect(mock_connection).to receive(:create_vehicle).with(estimate_id,
-                                                                         date_of_purchase: 2.years.ago.to_date,
-                                                                         value: vehicle_value,
-                                                                         loan_amount_outstanding: loan_amount,
-                                                                         in_regular_use: true)
+                # expect(mock_connection).to receive(:create_vehicle).with(estimate_id,
+                #                                                          date_of_purchase: 2.years.ago.to_date,
+                #                                                          value: vehicle_value,
+                #                                                          loan_amount_outstanding: loan_amount,
+                #                                                          in_regular_use: true)
 
                 click_on "Save and continue"
                 expect(page).to have_content assets_header
                 click_on "Back"
                 select_boolean_value("vehicle-finance-form", :vehicle_pcp, false)
-                expect(mock_connection).to receive(:create_vehicle).with(estimate_id,
-                                                                         date_of_purchase: 2.years.ago.to_date,
-                                                                         value: vehicle_value,
-                                                                         loan_amount_outstanding: 0,
-                                                                         in_regular_use: true)
+                # expect(mock_connection).to receive(:create_vehicle).with(estimate_id,
+                #                                                          date_of_purchase: 2.years.ago.to_date,
+                #                                                          value: vehicle_value,
+                #                                                          loan_amount_outstanding: 0,
+                #                                                          in_regular_use: true)
                 click_on "Save and continue"
               end
             end
 
             context "without a loan amount" do
               it "completes the journey successfully" do
-                expect(mock_connection)
-                  .to receive(:create_vehicle)
-                        .with(estimate_id,
-                              date_of_purchase: 2.years.ago.to_date,
-                              value: vehicle_value,
-                              loan_amount_outstanding: 0,
-                              in_regular_use: true)
+                # expect(mock_connection)
+                #   .to receive(:create_vehicle)
+                #         .with(estimate_id,
+                #               date_of_purchase: 2.years.ago.to_date,
+                #               value: vehicle_value,
+                #               loan_amount_outstanding: 0,
+                #               in_regular_use: true)
 
                 select_boolean_value("vehicle-finance-form", :vehicle_pcp, false)
                 click_on "Save and continue"
@@ -184,13 +181,13 @@ RSpec.describe "Vehicle Page" do
 
         context "without regular usage" do
           it "creates the vehicle immediately" do
-            expect(mock_connection)
-              .to receive(:create_vehicle)
-                    .with(estimate_id,
-                          date_of_purchase: Time.zone.today.to_date,
-                          value: vehicle_value,
-                          loan_amount_outstanding: 0,
-                          in_regular_use: false)
+            # expect(mock_connection)
+            #   .to receive(:create_vehicle)
+            #         .with(estimate_id,
+            #               date_of_purchase: Time.zone.today.to_date,
+            #               value: vehicle_value,
+            #               loan_amount_outstanding: 0,
+            #               in_regular_use: false)
             select_boolean_value("vehicle-value-form", :vehicle_in_regular_use, false)
             click_on "Save and continue"
 
@@ -198,8 +195,8 @@ RSpec.describe "Vehicle Page" do
           end
 
           it "has a working Back button" do
-            expect(mock_connection)
-              .to receive(:create_vehicle)
+            # expect(mock_connection)
+            #   .to receive(:create_vehicle)
             select_boolean_value("vehicle-value-form", :vehicle_in_regular_use, false)
             click_on "Save and continue"
             expect(page).to have_content assets_header

--- a/spec/system/accessibility_spec.rb
+++ b/spec/system/accessibility_spec.rb
@@ -64,11 +64,11 @@ RSpec.describe "Accessibility" do
 
   describe "Results page" do
     let(:estimate_id) { SecureRandom.uuid }
-    let(:mock_connection) { instance_double(CfeConnection, create_applicant: nil, api_result: CalculationResult.new({})) }
+    # let(:mock_connection) { instance_double(CfeConnection, create_applicant: nil, api_result: CalculationResult.new({})) }
 
     before do
       travel_to arbitrary_fixed_time
-      allow(CfeConnection).to receive(:connection).and_return(mock_connection)
+      # allow(CfeConnection).to receive(:connection).and_return(mock_connection)
       visit "/estimates/#{estimate_id}/build_estimates/summary"
       click_on "Submit"
     end


### PR DESCRIPTION
[Link to the Jira ticket](https://dsdmoj.atlassian.net/browse/EL-383)

Move the calls to CFE out of the individual handlers and into the `/estimates_controller`
Remove the CFE calls from the specs

Question: Is this the best way to do this? Any suggestions on refactoring? Or preferred alternatives?

Also where would tests for these sit? I am assuming in `spec/controllers/estimates_controller_spec.rb` but wasn't sure `spec/requests` was more appropriate.

Still to do: Add tests for the moved methods.

Checklist

Before you ask people to review this PR:

    Tests and rubocop should be passing
    Github should not be reporting conflicts; you should have recently run git rebase main.
    There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
    The PR description should say what you changed and why, with a link to the JIRA story.
    You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
    You should have checked that the commit messages say why the change was made.
