### PR TITLE
Fix sidebar slimdentation

### DIFF
--- a/app/views/shared/_sidebar_with_date.html.slim
+++ b/app/views/shared/_sidebar_with_date.html.slim
@@ -1,13 +1,13 @@
 = render "layouts/sidebar"
-h2.govuk-body-m
-  strong = t("generic.date")
-  p.govuk-body-m = Date.current.strftime("%d %B %Y")
-
-- if links.any?
   h2.govuk-body-m
-    strong = t("generic.related_content_title")
-    ul class="govuk-list govuk-!-font-size-16"
-      - links.each do |text, dest|
-        li
-          p
-            = link_to text, dest, target: "_blank", rel: "noopener", class: "govuk-link govuk-body-m"
+    strong = t("generic.date")
+    p.govuk-body-m = Date.current.strftime("%d %B %Y")
+
+  - if links.any?
+    h2.govuk-body-m
+      strong = t("generic.related_content_title")
+      ul class="govuk-list govuk-!-font-size-16"
+        - links.each do |text, dest|
+          li
+            p
+              = link_to text, dest, target: "_blank", rel: "noopener", class: "govuk-link govuk-body-m"


### PR DESCRIPTION
Somehow the sidebar html got wrongly indented so sidebar contents aren't being rendered inside the correct layout div.