### PR TITLE
Fix bug in income section

### DIFF
--- a/app/lib/income_section.rb
+++ b/app/lib/income_section.rb
@@ -9,7 +9,7 @@ class IncomeSection
         []
       else
         employment_step = estimate.employed ? [:employment] : []
-        employment_step + %i[benefits monthly_income outgoings].map { [_1] }
+        (employment_step + %i[benefits monthly_income outgoings]).map { [_1] }
       end
     end
   end


### PR DESCRIPTION
The XSection classes need to return an array of arrays of symbols, and Income Section was returning one symbol not wrapped in an extra array, causing occasional crashes on navigation.

Checklist

Before you ask people to review this PR:

    Tests and rubocop should be passing
    Github should not be reporting conflicts; you should have recently run git rebase main.
    There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
    The PR description should say what you changed and why, with a link to the JIRA story.
    You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
    You should have checked that the commit messages say why the change was made.
