### PR TITLE
EL-433: Show SMOD disregards in capital summary table

### DIFF
--- a/app/models/calculation_result.rb
+++ b/app/models/calculation_result.rb
@@ -42,12 +42,8 @@ class CalculationResult
     monetise(api_response.dig(:result_summary, :disposable_income, :proceeding_types)&.map { |pt| pt.fetch(:upper_threshold) }&.min)
   end
 
-  def total_capital
-    monetise(api_response.dig(:result_summary, :capital, :total_capital))
-  end
-
-  def total_capital_limit
-    monetise(api_response.dig(:result_summary, :capital, :proceeding_types)&.map { |pt| pt.fetch(:upper_threshold) }&.min)
+  def assessed_capital
+    monetise(api_response.dig(:result_summary, :capital, :assessed_capital))
   end
 
   def client_income_rows
@@ -82,12 +78,23 @@ class CalculationResult
 
   def client_capital_rows
     data = {
-      property: capital_items(:properties)&.dig(:main_home, :net_equity),
+      property: capital_items(:properties)&.dig(:main_home, :assessed_equity),
       vehicles: capital_items(:vehicles)&.sum(0) { |z| z.fetch(:assessed_value) },
       # unfortunately CFE returns capital items as strings rather than numbers for some reason.
-      second_property: capital_items(:properties)&.fetch(:additional_properties)&.sum(0) { |p| p.fetch(:net_equity).to_i },
+      second_property: capital_items(:properties)&.fetch(:additional_properties)&.sum(0) { |p| p.fetch(:assessed_equity).to_i },
       savings: capital_items(:liquid)&.sum(0) { |z| z.fetch(:value).to_i },
     }
+    data.transform_values { |value| monetise(value) }
+  end
+
+  def client_capital_subtotal_rows
+    data = {
+      total_capital: api_response.dig(:result_summary, :capital, :total_capital),
+      total_capital_limit: api_response.dig(:result_summary, :capital, :proceeding_types)&.map { |pt| pt.fetch(:upper_threshold) }&.min,
+      pensioner_capital_disregard: api_response.dig(:result_summary, :capital, :pensioner_capital_disregard),
+      smod_disregard: api_response.dig(:result_summary, :capital, :subject_matter_of_dispute_disregard),
+    }
+
     data.transform_values { |value| monetise(value) }
   end
 

--- a/app/views/estimates/_client_capital_table.html.slim
+++ b/app/views/estimates/_client_capital_table.html.slim
@@ -12,11 +12,10 @@
     - body.row do |row|
       - row.cell(header: true, text: t("estimates.show.client_capital_types.valuables"))
       - row.cell(text: number_to_money(@asset_model.valuables), numeric: true)
-= govuk_table do |table|
-  - table.body do |body|
-    - body.row(classes: %w[solid-top-border]) do |row|
-      - row.cell(header: true, text: t("estimates.show.total_capital"))
-      - row.cell(text: @model.total_capital, numeric: true)
+    - @model.client_capital_subtotal_rows.each_with_index do |type_and_amount, index|
+      - body.row(classes: (%w[solid-top-border] if index.zero?)) do |row|
+        - row.cell(header: true, text: t("estimates.show.client_capital_subtotal_types.#{type_and_amount[0]}"))
+        - row.cell(text: type_and_amount[1], numeric: true)
     - body.row(classes: %w[solid-bottom-border]) do |row|
-      - row.cell(header: true, text: t("estimates.show.total_capital_limit"))
-      - row.cell(text: @model.total_capital_limit, numeric: true)
+      - row.cell(header: true, text: t("estimates.show.assessed_capital"))
+      - row.cell(text: @model.assessed_capital, numeric: true)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -531,13 +531,17 @@ en:
         savings: Savings
         investments: Investments
         valuables: Valuable items worth £500 or more
+      client_capital_subtotal_types:
+        total_capital: Total capital
+        total_capital_limit: Disposable capital limit
+        pensioner_capital_disregard: Pensioner disregard
+        smod_disregard: Disputed asset disregard
       gross_monthly_income: Total gross monthly income
       gross_income_limit: Total gross income limit
       gross_monthly_outgoings: Total gross monthly outgoings
       disposable_monthly_income: Assessed disposable monthly income
       disposable_income_limit: Disposable monthly income limit
-      total_capital: Total capital
-      total_capital_limit: Disposable capital limit
+      assessed_capital: Disposable capital
       start_another_check: Start another eligibility check
       print_page: Print this page
     print:

--- a/spec/features/result_page_spec.rb
+++ b/spec/features/result_page_spec.rb
@@ -194,7 +194,7 @@ RSpec.describe "Results Page" do
 
     it "shows the capital section" do
       within "#capital-calculation-content" do
-        expect(page).to have_content "Property £3,400.00"
+        expect(page).to have_content "Property £0.00"
         expect(page).to have_content "Vehicles £2,500.00"
         expect(page).to have_content "Second property £3,800.00"
         expect(page).to have_content "Savings £200.00"


### PR DESCRIPTION
[Link to the Jira ticket](https://dsdmoj.atlassian.net/browse/EL-433)

The numbers in the capital table now "add up" - we show the assessed value of every sort of asset, then the total assessed value, then the disregards, then the assessed disposable capital which is the  total assessed value minus the disregards.

Checklist

Before you ask people to review this PR:

    Tests and rubocop should be passing
    Github should not be reporting conflicts; you should have recently run git rebase main.
    There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
    The PR description should say what you changed and why, with a link to the JIRA story.
    You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
    You should have checked that the commit messages say why the change was made.
