### PR TITLE
EL-437 Prompt for employment income frequency using radio buttons

### DIFF
--- a/app/views/estimate_flow/employment.html.slim
+++ b/app/views/estimate_flow/employment.html.slim
@@ -8,17 +8,16 @@
   = form_for(@form, url: wizard_path, method: :put) do |form|
     = form.govuk_error_summary t("generic.error_summary_title")
 
+    = form.govuk_collection_radio_buttons :frequency,
+            @form.frequency_options,
+            :value,
+            :label,
+            legend: { text: t(".frequency.input") }
     - EmploymentForm::DECIMAL_ATTRIBUTES.each do |field|
       = render "shared/money_input",
                 form:,
                 field:,
                 width: 5,
                 label_text: t(".#{field}.input")
-    = form.govuk_collection_select :frequency,
-                                   @form.frequency_options,
-                                   :value,
-                                   :label,
-                                   label: { text: t(".frequency.input") },
-                                   options: { include_blank: t(".frequency.blank") }
     = form.govuk_submit t("generic.save_and_continue")
 = render "shared/sidebar_with_date", links: []

--- a/spec/features/employment_page_spec.rb
+++ b/spec/features/employment_page_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe "Employment page" do
         fill_in "employment-form-gross-income-field", with: 100
         fill_in "employment-form-income-tax-field", with: 100
         fill_in "employment-form-national-insurance-field", with: 50
-        select "Monthly", from: "employment-form-frequency-field"
+        click_checkbox("employment-form-frequency", "monthly")
         click_on "Save and continue"
       end
 
@@ -79,7 +79,7 @@ RSpec.describe "Employment page" do
         fill_in "employment-form-gross-income-field", with: "5,000"
         fill_in "employment-form-income-tax-field", with: "1000"
         fill_in "employment-form-national-insurance-field", with: 50.5
-        select "Monthly", from: "employment-form-frequency-field"
+        click_checkbox("employment-form-frequency", "monthly")
       end
 
       it "persists my answers to CFE and moves me on to the next question" do
@@ -120,7 +120,8 @@ RSpec.describe "Employment page" do
           expect(payment[:gross]).to eq (1_000 / 3.0).round(2)
           expect(payment[:date]).to eq 1.month.ago.to_date
         end
-        select "Total in last 3 months", from: "employment-form-frequency-field"
+        click_checkbox("employment-form-frequency", "total")
+
         click_on "Save and continue"
         progress_to_submit_from_benefits
       end
@@ -131,7 +132,7 @@ RSpec.describe "Employment page" do
           expect(payment[:gross]).to eq 1_000
           expect(payment[:date]).to eq 1.week.ago.to_date
         end
-        select "Every week", from: "employment-form-frequency-field"
+        click_checkbox("employment-form-frequency", "week")
         click_on "Save and continue"
         progress_to_submit_from_benefits
       end
@@ -142,7 +143,7 @@ RSpec.describe "Employment page" do
           expect(payment[:gross]).to eq 1_000
           expect(payment[:date]).to eq 2.weeks.ago.to_date
         end
-        select "Every two weeks", from: "employment-form-frequency-field"
+        click_checkbox("employment-form-frequency", "two_weeks")
         click_on "Save and continue"
         progress_to_submit_from_benefits
       end
@@ -153,7 +154,7 @@ RSpec.describe "Employment page" do
           expect(payment[:gross]).to eq 1_000
           expect(payment[:date]).to eq 4.weeks.ago.to_date
         end
-        select "Every four weeks", from: "employment-form-frequency-field"
+        click_checkbox("employment-form-frequency", "four_weeks")
         click_on "Save and continue"
         progress_to_submit_from_benefits
       end
@@ -164,7 +165,7 @@ RSpec.describe "Employment page" do
           expect(payment[:gross]).to eq (1_000 / 12.0).round(2)
           expect(payment[:date]).to eq 1.month.ago.to_date
         end
-        select "Annually", from: "employment-form-frequency-field"
+        click_checkbox("employment-form-frequency", "annually")
         click_on "Save and continue"
         progress_to_submit_from_benefits
       end

--- a/spec/features/result_page_spec.rb
+++ b/spec/features/result_page_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe "Results Page" do
       fill_in "employment-form-gross-income-field", with: 1000
       fill_in "employment-form-income-tax-field", with: 400
       fill_in "employment-form-national-insurance-field", with: 50
-      select "Monthly", from: "employment-form-frequency-field"
+      click_checkbox("employment-form-frequency", "monthly")
       click_on "Save and continue"
 
       select_boolean_value("benefits-form", :add_benefit, false)

--- a/spec/system/employment_page_spec.rb
+++ b/spec/system/employment_page_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "Employment Page", :vcr do
       fill_in "employment-form-gross-income-field", with: 1000
       fill_in "employment-form-income-tax-field", with: 100
       fill_in "employment-form-national-insurance-field", with: 50
-      select "Every week", from: "employment-form-frequency-field"
+      click_checkbox("employment-form-frequency", "week")
       click_on "Save and continue"
       expect(page).to have_content(benefits_header)
       select_boolean_value("benefits-form", :add_benefit, false)


### PR DESCRIPTION
In research, providers have been confused about entering the amount of salary before the frequency, so move the frequency first. Convert to a set of radio buttons for accessibility.

https://dsdmoj.atlassian.net/browse/EL-437