### PR TITLE
add github action to delete UAT release on merge or close of PR

### DIFF
--- a/.github/actions/delete-uat-release/action.yml
+++ b/.github/actions/delete-uat-release/action.yml
@@ -1,0 +1,79 @@
+name: "Delete UAT deployment"
+description: 'Deletes a UAT deployment with a name that matches the merged or closed branch'
+inputs:
+  k8s_cluster:
+    description: "Kubernetes cluster name"
+    required: true
+  k8s_cluster_cert:
+    description: "Kubernetes cluster certificate"
+    required: true
+  k8s_namespace:
+    description: "Kubernetes cluster namespace"
+    required: true
+  k8s_token:
+    description: "Kubernetes authentication token"
+    required: true
+outputs:
+  branch-name:
+    description: "Extracted branch name"
+    value: ${{ steps.extract_branch.outputs.branch }}
+  release-name:
+    description: "Extracted release name"
+    value: ${{ steps.extract_release.outputs.release }}
+  delete-message:
+    description: "Extracted delete message"
+    value: ${{ steps.delete_release.outputs.message }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Extract branch name
+      id: extract_branch
+      shell: bash
+      run: |
+        if [ $GITHUB_EVENT_NAME == "pull_request" ]
+        then
+          branch=$GITHUB_HEAD_REF
+        else
+          branch=${GITHUB_REF#refs/heads/}
+        fi
+
+        echo "##[set-output name=branch;]$(echo $branch)"
+
+    - name: Extract release name
+      id: extract_release
+      shell: bash
+      run: |
+        branch=${{ steps.extract_branch.outputs.branch }}
+        truncated_branch=$(echo $branch | tr '[:upper:]' '[:lower:]' | sed 's:^\w*\/::' | tr -s ' _/[]().' '-' | cut -c1-20 | sed 's/-$//')
+        echo "##[set-output name=release;]$(echo $truncated_branch)"
+
+    - name: Authenticate to the cluster
+      id: authenticate_to_cluster
+      shell: bash
+      env:
+        K8S_CLUSTER: ${{ inputs.k8s_cluster }}
+        K8S_CLUSTER_CERT: ${{ inputs.k8s_cluster_cert }}
+        K8S_NAMESPACE: ${{ inputs.k8s_namespace }}
+        K8S_TOKEN: ${{ inputs.k8s_token }}
+      run: |
+        echo "${K8S_CLUSTER_CERT}" > ./ca.crt
+        kubectl config set-cluster ${K8S_CLUSTER} --certificate-authority=./ca.crt --server=https://${K8S_CLUSTER}
+        kubectl config set-credentials circleci --token=${K8S_TOKEN}
+        kubectl config set-context ${K8S_CLUSTER} --cluster=${K8S_CLUSTER} --user=circleci --namespace=${K8S_NAMESPACE}
+        kubectl config use-context ${K8S_CLUSTER}
+
+    - name: Delete UAT release
+      id: delete_release
+      shell: bash
+      run: |
+        release_name=${{ steps.extract_release.outputs.release }}
+        found=$(helm list --all | grep $release_name || [[ $? == 1 ]])
+
+        if [[ ! -z "$found" ]]
+        then
+          helm delete $release_name
+          echo "##[set-output name=message;]$(echo "Deleted UAT release ${release_name}!")"
+        else
+          echo "##[set-output name=message;]$(echo "UAT release, ${release_name}, not found!")"
+        fi

--- a/.github/workflows/delete_uat_release.yml
+++ b/.github/workflows/delete_uat_release.yml
@@ -1,0 +1,23 @@
+name: Delete UAT release
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  delete_uat_job:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Delete UAT release action
+        id: delete_uat
+        uses: ./.github/actions/delete-uat-release
+        with:
+          k8s_cluster: ${{ secrets.K8S_GHA_UAT_CLUSTER_NAME }}
+          k8s_cluster_cert: ${{ secrets.K8S_GHA_UAT_CLUSTER_CERT }}
+          k8s_namespace: ${{ secrets.K8S_GHA_UAT_NAMESPACE }}
+          k8s_token: ${{ secrets.K8S_GHA_UAT_TOKEN }}
+      - name: Result
+        shell: bash
+        run: echo ${{ steps.delete_uat.outputs.delete-message }}\


### PR DESCRIPTION
Add a github action to delete UAT releases when a PR is merged with main or closed.
Add secrets to the repo via the cloud platform namespace - https://github.com/ministryofjustice/cloud-platform-environments/pull/9101

The circleci job does not delete UAT releases when a PR is opened and subsequently closed without merging. This job will be removed in a subsequent PR

Checklist

Before you ask people to review this PR:

    Tests and rubocop should be passing
    Github should not be reporting conflicts; you should have recently run git rebase main.
    There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
    The PR description should say what you changed and why, with a link to the JIRA story.
    You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
    You should have checked that the commit messages say why the change was made.
