### PR TITLE
EL-445: Fix 'delete the only benefit' flow

### DIFF
--- a/app/controllers/benefits_controller.rb
+++ b/app/controllers/benefits_controller.rb
@@ -42,11 +42,7 @@ class BenefitsController < EstimateFlowController
 
   def destroy
     session_data["benefits"].delete_if { _1["id"] == params["id"] }
-    if session_data["benefits"].any?
-      redirect_to flow_path(:benefits)
-    else
-      redirect_to new_path
-    end
+    redirect_to post_destroy_path
   end
 
   def add
@@ -76,5 +72,13 @@ private
 
   def next_step_path(model)
     flow_path StepsHelper.next_step_for(model, :benefits)
+  end
+
+  def post_destroy_path
+    if session_data["benefits"].any?
+      flow_path(:benefits)
+    else
+      new_path
+    end
   end
 end

--- a/app/controllers/check_benefits_answers_controller.rb
+++ b/app/controllers/check_benefits_answers_controller.rb
@@ -17,4 +17,8 @@ private
       check_answers_estimate_path estimate_id, anchor: "other_income-section"
     end
   end
+
+  def post_destroy_path
+    flow_path(:benefits)
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -50,4 +50,12 @@ module ApplicationHelper
       send("#{prefix}estimate_#{controller}s_path", params[:estimate_id])
     end
   end
+
+  def flow_path(estimate_id, step, check_answers: false)
+    if check_answers
+      estimate_check_answer_path(estimate_id, step)
+    else
+      estimate_build_estimate_path(estimate_id, step)
+    end
+  end
 end

--- a/app/views/benefits/edit.html.slim
+++ b/app/views/benefits/edit.html.slim
@@ -1,5 +1,7 @@
 - content_for :back
-  = link_to t("generic.back"), "javascript:history.back()", class: "govuk-back-link"
+  = link_to t("generic.back"),
+            flow_path(params[:estimate_id], :benefits, check_answers: controller_name == "check_benefits_answers"),
+            class: "govuk-back-link"
 
 .govuk-grid-column-two-thirds
   span.govuk-caption-l = t(".caption")

--- a/app/views/benefits/new.html.slim
+++ b/app/views/benefits/new.html.slim
@@ -1,5 +1,7 @@
 - content_for :back
-  = link_to t("generic.back"), "javascript:history.back()", class: "govuk-back-link"
+  = link_to t("generic.back"),
+            flow_path(params[:estimate_id], :benefits, check_answers: controller_name == "check_benefits_answers"),
+            class: "govuk-back-link"
 
 .govuk-grid-column-two-thirds
   span.govuk-caption-l = t(".caption")

--- a/spec/features/check_answers_page_spec.rb
+++ b/spec/features/check_answers_page_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "Check answers page" do
       end
     end
 
-    scenario "I can add and remove those benefits from the 'check answers' screen" do
+    scenario "I can add more benefits from the 'check answers' screen" do
       within("#subsection-benefits-header") { click_on "Change" }
 
       select_boolean_value("benefits-form", :add_benefit, true)
@@ -44,7 +44,23 @@ RSpec.describe "Check answers page" do
       choose "Every week"
       click_on "Save and continue"
 
-      find(".button-as-link", match: :first).click
+      select_boolean_value("benefits-form", :add_benefit, false)
+      click_on "Save and continue"
+
+      expect(page).to have_current_path(check_answers_estimate_path(estimate_id))
+
+      within("#field-list-benefits") do
+        expect(page).to have_content "Child benefit"
+        expect(page).to have_content "Universal credit"
+      end
+    end
+
+    scenario "I can remove benefits from the 'check answers' screen" do
+      visit check_answers_estimate_path(estimate_id)
+
+      within("#subsection-benefits-header") { click_on "Change" }
+
+      click_on "Remove"
 
       select_boolean_value("benefits-form", :add_benefit, false)
       click_on "Save and continue"
@@ -53,7 +69,6 @@ RSpec.describe "Check answers page" do
 
       within("#field-list-benefits") do
         expect(page).not_to have_content "Child benefit"
-        expect(page).to have_content "Universal credit"
       end
     end
   end


### PR DESCRIPTION
[Link to the Jira ticket](https://dsdmoj.atlassian.net/browse/EL-445)

In the normal run of things, when you delete the only benefit you get taken to the 'add a benefit' screen. This was a deliberately requested feature. If you don't _want_ to add a benefit your only option is to click 'Back'. Because this was previously a JS-powered back button, it would take you back to the benefits list screen without triggering a page refresh... which would mean you would still see the benefit you'd just remove listed.

So this PR removes the JS-powered back and replaces it with a proper back button.

Also, if from the check answers screen you choose to 'Remove' the benefit rather than 'Change' it, that suggests you don't want to replace the benefit with a different one. So it would not be appropriate to put you into the 'add benefit' screen. This PR makes the adjustment so that we don't do that.