### PR TITLE
EL-446 Don't display dependants questions when user is passported

### DIFF
--- a/app/lib/applicant_case_details_section.rb
+++ b/app/lib/applicant_case_details_section.rb
@@ -5,14 +5,18 @@ class ApplicantCaseDetailsSection
     end
 
     def steps_for(estimate)
-      [
+      steps = [
         [:case_details],
         [:applicant],
-        [
-          :dependants,
-          (:dependant_details if estimate.dependants),
-        ].compact,
       ]
+      unless estimate.passporting
+        steps <<
+          [
+            :dependants,
+            (:dependant_details if estimate.dependants),
+          ].compact
+      end
+      steps
     end
   end
 end

--- a/spec/features/applicant_page_spec.rb
+++ b/spec/features/applicant_page_spec.rb
@@ -72,8 +72,6 @@ RSpec.describe "Applicant Page" do
       select_applicant_boolean(:passporting, true)
       click_on "Save and continue"
 
-      complete_dependants_section
-
       click_checkbox("property-form-property-owned", "none")
       click_on "Save and continue"
       select_boolean_value("vehicle-form", :vehicle_owned, false)

--- a/spec/features/change_employment_type_spec.rb
+++ b/spec/features/change_employment_type_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe "ChangeEmploymentTypes" do
 
     click_on "Save and continue"
 
-    complete_dependants_section
     click_checkbox("property-form-property-owned", "none")
     click_on "Save and continue"
 
@@ -25,6 +24,7 @@ RSpec.describe "ChangeEmploymentTypes" do
     select_applicant_boolean(:employed, true)
     select_applicant_boolean(:passporting, false)
     click_on "Save and continue"
+    complete_dependants_section
     expect(page).to have_content employment_header
     fill_in "employment-form-gross-income-field", with: "5,000"
     fill_in "employment-form-income-tax-field", with: "1000"

--- a/spec/support/form_helpers.rb
+++ b/spec/support/form_helpers.rb
@@ -109,7 +109,6 @@ def visit_check_answer_with_passporting_benefit
   visit_applicant_page
   fill_in_applicant_screen_with_passporting_benefits
   click_on "Save and continue"
-  complete_dependants_section
 
   click_checkbox("property-form-property-owned", "none")
   click_on "Save and continue"

--- a/spec/system/assets_page_spec.rb
+++ b/spec/system/assets_page_spec.rb
@@ -14,8 +14,6 @@ RSpec.describe "Assets Page", :vcr do
     fill_in_applicant_screen_with_passporting_benefits
     click_on "Save and continue"
 
-    complete_dependants_section
-
     click_checkbox("property-form-property-owned", "with_mortgage")
     click_on "Save and continue"
     fill_in "property-entry-form-house-value-field", with: 100_000

--- a/spec/system/vehicle_page_spec.rb
+++ b/spec/system/vehicle_page_spec.rb
@@ -38,7 +38,6 @@ RSpec.describe "Vehicle Page", :vcr do
     visit_applicant_page
     fill_in_applicant_screen_with_passporting_benefits
     click_on "Save and continue"
-    complete_dependants_section
 
     click_checkbox("property-form-property-owned", "none")
     click_on "Save and continue"


### PR DESCRIPTION
When a client is receiving passported benefits, their dependants do not contribute to the calculation of eligibility, so don't ask the question in that case

https://dsdmoj.atlassian.net/browse/EL-446