### PR TITLE
EL-450: Compensate for CFE's over-eager pensioner disregard

### DIFF
--- a/app/models/calculation_result.rb
+++ b/app/models/calculation_result.rb
@@ -50,7 +50,12 @@ class CalculationResult
   end
 
   def assessed_capital
-    monetise(api_response.dig(:result_summary, :capital, :assessed_capital))
+    # If the pensioner_capital_disregard is applied, it is applied by CFE in full even when the disregard is
+    # greater than the client's total capital value. This can lead to the CFE 'assessed capital' figure
+    # being a negative number, which is unsuitable for display to the end user.
+    # Therefore we must correct the CFE result to display a zero if it comes back negative.
+    cfe_result = api_response.dig(:result_summary, :capital, :assessed_capital)
+    monetise([cfe_result, 0].compact.max)
   end
 
   def client_income_rows

--- a/spec/features/result_page_spec.rb
+++ b/spec/features/result_page_spec.rb
@@ -21,6 +21,12 @@ RSpec.describe "Results Page" do
               "gross_income": 123.56,
             },
           },
+          "capital": {
+            "total_capital": 10_000,
+            "pensioner_capital_disregard": 100_000,
+            "subject_matter_of_dispute_disregard": 3_000,
+            "assessed_capital": -97_000,
+          },
         },
         "assessment": {
           "gross_income": {
@@ -74,6 +80,10 @@ RSpec.describe "Results Page" do
 
       it "show eligible" do
         expect(page).to have_content "Your client appears provisionally eligible for legal aid based on the information provided."
+      end
+
+      it "zeroes out the negative assessed capital figure" do
+        expect(page).to have_content "Disposable capital £0.00"
       end
     end
 


### PR DESCRIPTION
[Link to the Jira ticket](https://dsdmoj.atlassian.net/browse/EL-450)

When CFE thinks a client has no relevant disposable capital it sometimes expresses it as negative disposable capital (specifically if the client has < £100k of disposable capital and is over 60, so has a £100k pensioner disregard applied). This PR ensures that when the assessed capital returned by CFE is negative, we show a zero to the user instead of a negative number.

Checklist

Before you ask people to review this PR:

    Tests and rubocop should be passing
    Github should not be reporting conflicts; you should have recently run git rebase main.
    There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
    The PR description should say what you changed and why, with a link to the JIRA story.
    You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
    You should have checked that the commit messages say why the change was made.
