### PR TITLE
Re-add conditional logic around partner field display

### DIFF
--- a/app/services/check_answers/applicant_section.rb
+++ b/app/services/check_answers/applicant_section.rb
@@ -9,7 +9,9 @@ module CheckAnswers
                 passporting
                 dependants
                 child_dependants
-                adult_dependants].freeze
+                adult_dependants
+                partner_employed
+                partner_over_60].freeze
 
     attribute :over_60, :boolean
     attribute :partner, :boolean
@@ -18,6 +20,8 @@ module CheckAnswers
     attribute :dependants, :boolean
     attribute :child_dependants, :integer
     attribute :adult_dependants, :integer
+    attribute :partner_employed, :boolean
+    attribute :partner_over_60, :boolean
 
     class << self
       def from_session(session)
@@ -26,7 +30,11 @@ module CheckAnswers
     end
 
     def display_fields
-      @display_fields ||= FIELDS
+      if partner
+        FIELDS
+      else
+        FIELDS - %i[partner_employed partner_over_60]
+      end
     end
 
     def disputed_asset?(_field)

--- a/spec/features/applicant_page_spec.rb
+++ b/spec/features/applicant_page_spec.rb
@@ -139,6 +139,20 @@ RSpec.describe "Applicant Page" do
       click_on "Save and continue"
       expect(page).not_to have_css(".govuk-error-summary__list")
     end
+
+    it "shows me partner details on the check answers screen" do
+      select_applicant_boolean(:over_60, false)
+      select_applicant_boolean(:employed, false)
+      select_applicant_boolean(:passporting, true)
+      select_applicant_boolean(:partner_over_60, true)
+      select_applicant_boolean(:partner_employed, false)
+      click_on "Save and continue"
+      skip_property_form
+      select_boolean_value("vehicle-form", :vehicle_owned, false)
+      click_on "Save and continue"
+      skip_assets_form
+      expect(page).to have_content "Partner is employedNo"
+    end
   end
 
   describe "applicant page flow", :vcr do


### PR DESCRIPTION
The SMOD merge accidentally removed some work done after it to show partner employment and age summaries on the check answers screen. This re-adds that work (doing it differently this time to use the new `Section` object) and adds a test to make sure it can't go missing again.