### PR TITLE
EL-525 part one - rework applicant spec (and re-ordered form validation)

### DIFF
--- a/app/forms/applicant_form.rb
+++ b/app/forms/applicant_form.rb
@@ -6,15 +6,15 @@ class ApplicantForm
   PROCEEDING_TYPES = { domestic_abuse: "DA001", other: "SE003" }.freeze
 
   PROCEEDING_ATTRIBUTE = %i[proceeding_type].freeze
-  BOOLEAN_ATTRIBUTES = %i[passporting over_60 employed partner].freeze
+  BOOLEAN_ATTRIBUTES = %i[over_60 employed partner passporting].freeze
 
   ATTRIBUTES = BOOLEAN_ATTRIBUTES + PROCEEDING_ATTRIBUTE.freeze
+
+  attribute :proceeding_type
+  validates :proceeding_type, presence: true, inclusion: { in: PROCEEDING_TYPES.values, allow_nil: true }
 
   BOOLEAN_ATTRIBUTES.each do |attr|
     attribute attr, :boolean
     validates attr, inclusion: { in: [true, false] }, if: -> { Flipper.enabled?(:partner) || attr != :partner }
   end
-
-  attribute :proceeding_type
-  validates :proceeding_type, presence: true, inclusion: { in: PROCEEDING_TYPES.values, allow_nil: true }
 end


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/EL-525

Rework applicant spec, resulting in improved tests and tweak to applicant form validation so that errors appear in a logical order