### PR TITLE
EL-540 match truncated branch length to deployment task

### DIFF
--- a/.github/actions/delete-uat-release/action.yml
+++ b/.github/actions/delete-uat-release/action.yml
@@ -45,7 +45,7 @@ runs:
       shell: bash
       run: |
         branch=${{ steps.extract_branch.outputs.branch }}
-        truncated_branch=$(echo $branch | tr '[:upper:]' '[:lower:]' | sed 's:^\w*\/::' | tr -s ' _/[]().' '-' | cut -c1-20 | sed 's/-$//')
+        truncated_branch=$(echo $branch | tr '[:upper:]' '[:lower:]' | sed 's:^\w*\/::' | tr -s ' _/[]().' '-' | cut -c1-18 | sed 's/-$//')
         echo "##[set-output name=release;]$(echo $truncated_branch)"
 
     - name: Authenticate to the cluster


### PR DESCRIPTION
[Link to the Jira ticket](https://dsdmoj.atlassian.net/browse/EL-540)

the ticket for this is still being pointed but the effort of managing it manually is more than making the change (we are up to 12 deployments (24 pods) again already)

When the name was changed we reduced the release name by 2 characters but I forgot to update the github action to match so it has been looking for releases that dont exist

Describe what you did and why.

Checklist

Before you ask people to review this PR:

    Tests and rubocop should be passing
    Github should not be reporting conflicts; you should have recently run git rebase main.
    There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
    The PR description should say what you changed and why, with a link to the JIRA story.
    You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
    You should have checked that the commit messages say why the change was made.
