### PR TITLE
EL-565: smarter number fields

### DIFF
--- a/app/forms/base_assets_form.rb
+++ b/app/forms/base_assets_form.rb
@@ -19,7 +19,7 @@ class BaseAssetsForm
   validates :property_mortgage, numericality: { greater_than_or_equal_to: 0, allow_nil: true }, presence: true,
                                 if: -> { property_value.to_i.positive? }
 
-  attribute :property_percentage_owned, :integer
+  attribute :property_percentage_owned, :fully_validatable_integer
   validates :property_percentage_owned,
             numericality: { greater_than: 0, only_integer: true, less_than_or_equal_to: 100, allow_nil: true },
             presence: true, if: -> { property_value.to_i.positive? }

--- a/app/forms/base_property_entry_form.rb
+++ b/app/forms/base_property_entry_form.rb
@@ -15,7 +15,7 @@ class BasePropertyEntryForm
             numericality: { greater_than: 0, allow_nil: true },
             presence: { if: -> { property_owned == "with_mortgage" } }
 
-  attribute :percentage_owned, :integer
+  attribute :percentage_owned, :fully_validatable_integer
   validates :percentage_owned,
             numericality: { greater_than: 0, only_integer: true, less_than_or_equal_to: 100, allow_nil: true, message: :within_range },
             presence: true

--- a/app/forms/client_property_entry_form.rb
+++ b/app/forms/client_property_entry_form.rb
@@ -9,7 +9,7 @@ class ClientPropertyEntryForm < BasePropertyEntryForm
   attribute :joint_ownership, :boolean
   validates :joint_ownership, inclusion: { in: [true, false] }, allow_nil: false, if: -> { partner }
 
-  attribute :joint_percentage_owned, :integer
+  attribute :joint_percentage_owned, :fully_validatable_integer
   validates :joint_percentage_owned,
             presence: true,
             numericality: { only_integer: true, greater_than: 0, less_than_or_equal_to: 100, message: :within_range },

--- a/app/forms/dependant_details_form.rb
+++ b/app/forms/dependant_details_form.rb
@@ -13,7 +13,9 @@ class DependantDetailsForm
   FORM_ATTRIBUTES.each do |boolean_field, integer_field|
     attribute boolean_field, :boolean
     validates boolean_field, inclusion: { in: [true, false] }
-    attribute integer_field, :integer
-    validates integer_field, presence: true, numericality: { greater_than: 0 }, if: ->(m) { m.public_send(boolean_field) }
+    attribute integer_field, :fully_validatable_integer
+    validates integer_field, presence: true,
+                             numericality: { greater_than: 0, only_integer: true },
+                             if: ->(m) { m.public_send(boolean_field) }
   end
 end

--- a/app/forms/employment_form.rb
+++ b/app/forms/employment_form.rb
@@ -8,7 +8,7 @@ class EmploymentForm
 
   DECIMAL_ATTRIBUTES.each do |attribute|
     attribute attribute, :gbp
-    validates attribute, presence: true
+    validates attribute, presence: true, numericality: true
   end
 
   validate :net_income_must_be_positive

--- a/app/forms/other_income_form.rb
+++ b/app/forms/other_income_form.rb
@@ -15,7 +15,7 @@ class OtherIncomeForm
     value_attribute = :"#{income_type}_value"
 
     attribute value_attribute, :gbp
-    validates value_attribute, presence: true
+    validates value_attribute, presence: true, numericality: true
 
     next unless REGULAR_INCOME_TYPES.include?(income_type)
 

--- a/app/forms/outgoings_form.rb
+++ b/app/forms/outgoings_form.rb
@@ -16,7 +16,7 @@ class OutgoingsForm
     attribute value_attribute, :gbp
     attribute frequency_attribute, :string
 
-    validates value_attribute, presence: true
+    validates value_attribute, presence: true, numericality: true
     validates frequency_attribute, presence: true,
                                    inclusion: { in: VALID_FREQUENCIES, allow_nil: false },
                                    if: -> { send(value_attribute)&.positive? }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -20,9 +20,18 @@ module ApplicationHelper
 
   def decimal_as_money_string(form, field)
     current_value = form.object.attributes[field.to_s]
+    return current_value if current_value.is_a?(String)
+
     precision = current_value&.round == current_value ? 0 : 2
 
     number_with_precision(current_value, precision:, delimiter: ",")
+  end
+
+  def integer_field_value(form, field)
+    current_value = form.object.attributes[field.to_s]
+    return current_value if current_value.is_a?(String)
+
+    number_with_precision(current_value, precision: 0, delimiter: ",")
   end
 
   def back_link(step, estimate, mimic_browser_back)

--- a/app/services/check_answers/other_section.rb
+++ b/app/services/check_answers/other_section.rb
@@ -8,7 +8,7 @@ module CheckAnswers
     attribute :investments, :gbp
     attribute :valuables, :gbp
     attribute :property_mortgage, :gbp
-    attribute :property_percentage_owned, :integer
+    attribute :property_percentage_owned, :fully_validatable_integer
     attribute :in_dispute, array: true, default: []
 
     FIELDS = %i[property_value

--- a/app/views/estimate_flow/forms/_assets.html.slim
+++ b/app/views/estimate_flow/forms/_assets.html.slim
@@ -16,9 +16,10 @@
             field: :property_mortgage,
             width: 5,
             label_text: t("estimate_flow.#{i18n_key}.property.mortgage.label")
-    = form.govuk_number_field :property_percentage_owned,
+    = form.govuk_text_field :property_percentage_owned,
             width: 5,
             suffix_text: "%",
+            value: integer_field_value(form, :property_percentage_owned),
             label: { text: t("estimate_flow.#{i18n_key}.property.percentage_owned.input") },
             hint: { text: t("estimate_flow.#{i18n_key}.property.percentage_owned.input_hint") }
 

--- a/app/views/estimate_flow/forms/_dependant_details.html.slim
+++ b/app/views/estimate_flow/forms/_dependant_details.html.slim
@@ -7,8 +7,9 @@
               legend: { text: t("estimate_flow.#{i18n_key}.child_dependants.legend") } do
     = form.govuk_radio_button :child_dependants, true,
             label: { text: t("generic.yes_choice") } do
-      = form.govuk_number_field :child_dependants_count,
+      = form.govuk_text_field :child_dependants_count,
           width: 5,
+          value: integer_field_value(form, :child_dependants_count),
           label: { text: t("estimate_flow.#{i18n_key}.child_dependants.label") }
     = form.govuk_radio_button :child_dependants, false,
             label: { text: t("generic.no_choice") }
@@ -18,8 +19,9 @@
           legend: { text: t("estimate_flow.#{i18n_key}.adult_dependants.legend") } do
     = form.govuk_radio_button :adult_dependants, true,
             label: { text: t("generic.yes_choice") } do
-      = form.govuk_number_field :adult_dependants_count,
+      = form.govuk_text_field :adult_dependants_count,
           width: 5,
+          value: integer_field_value(form, :adult_dependants_count),
           label: { text: t("estimate_flow.#{i18n_key}.adult_dependants.label") }
     = form.govuk_radio_button :adult_dependants, false,
             label: { text: t("generic.no_choice") }

--- a/app/views/estimate_flow/forms/_property_entry.html.slim
+++ b/app/views/estimate_flow/forms/_property_entry.html.slim
@@ -16,9 +16,10 @@
              label_text: t("estimate_flow.#{i18n_key}.mortgage.input"),
              hint_text: t("estimate_flow.#{i18n_key}.mortgage.input_hint")
 
-  = form.govuk_number_field :percentage_owned,
+  = form.govuk_text_field :percentage_owned,
                             width: 3,
                             suffix_text: "%",
+                            value: integer_field_value(form, :percentage_owned),
                             label: { text: t("estimate_flow.#{i18n_key}.percentage_owned.input"), size: "m" },
                             hint: { text: t("estimate_flow.#{i18n_key}.percentage_owned.input_hint") }
 
@@ -28,9 +29,10 @@
             legend: { text: t("estimate_flow.#{i18n_key}.joint_ownership.legend") } do
       = form.govuk_radio_button :joint_ownership, true,
               label: { text: t("generic.yes_choice") } do
-        = form.govuk_number_field :joint_percentage_owned,
+        = form.govuk_text_field :joint_percentage_owned,
                 width: 3,
                 suffix_text: "%",
+                value: integer_field_value(form, :joint_percentage_owned),
                 label: { text: t("estimate_flow.#{i18n_key}.joint_percentage_owned.input"), size: "m" }
 
       = form.govuk_radio_button :joint_ownership, false,

--- a/config/initializers/attribute_types.rb
+++ b/config/initializers/attribute_types.rb
@@ -1,9 +1,28 @@
 class Gbp < ActiveModel::Type::Decimal
-  # When a monetary value is provided by a form submission, we are only interested
-  # in the value to 2 decimal places, and discard any more fine detail immediately
   def cast(value)
-    super(value&.to_s&.delete(","))&.round(2)
+    if value.is_a?(Numeric) || value.blank? || value.gsub(/[0-9,.]/, "").empty?
+      # When a monetary value is provided by a form submission, we are only interested
+      # in the value to 2 decimal places, and discard any more fine detail immediately
+      super(value&.to_s&.delete(","))&.round(2)
+    else
+      # If the user has entered a string that is not straightforwardly parseable
+      # as an integer, retain the original value so we can display it back to the user
+      value
+    end
+  end
+end
+
+class FullyValidatableInteger < ActiveModel::Type::Integer
+  def cast(value)
+    if value.is_a?(Integer) || value.blank? || value.gsub(/[0-9,]/, "").empty?
+      super(value&.to_s&.delete(","))
+    else
+      # If the user has entered a string that is not straightforwardly parseable
+      # as an integer, retain the original value so we can display it back to the user
+      value
+    end
   end
 end
 
 ActiveModel::Type.register(:gbp, Gbp)
+ActiveModel::Type.register(:fully_validatable_integer, FullyValidatableInteger)

--- a/config/initializers/attribute_types.rb
+++ b/config/initializers/attribute_types.rb
@@ -1,9 +1,9 @@
 class Gbp < ActiveModel::Type::Decimal
   def cast(value)
-    if value.is_a?(Numeric) || value.blank? || value.gsub(/[0-9,.]/, "").empty?
+    if value.is_a?(Numeric) || value.blank? || value.gsub(/[0-9,.£]/, "").empty?
       # When a monetary value is provided by a form submission, we are only interested
       # in the value to 2 decimal places, and discard any more fine detail immediately
-      super(value&.to_s&.delete(","))&.round(2)
+      super(value&.to_s&.delete(",")&.delete("£"))&.round(2)
     else
       # If the user has entered a string that is not straightforwardly parseable
       # as an integer, retain the original value so we can display it back to the user

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -49,6 +49,7 @@ en:
               blank: Income tax cannot be blank
             national_insurance:
               blank: National Insurance cannot be blank
+              not_a_number: National Insurance must be a number, if this does not apply enter 0
             frequency:
               blank: Please select how frequently you receive employment income
         partner_employment_form:

--- a/spec/features/assets_page_spec.rb
+++ b/spec/features/assets_page_spec.rb
@@ -27,8 +27,8 @@ RSpec.describe "Assets Page" do
             fill_in "client-assets-form-investments-field", with: "0"
             fill_in "client-assets-form-valuables-field", with: "0"
 
-            fill_in "client-assets-form-property-value-field", with: "100_000"
-            fill_in "client-assets-form-property-mortgage-field", with: "50_000"
+            fill_in "client-assets-form-property-value-field", with: "100,000"
+            fill_in "client-assets-form-property-mortgage-field", with: "50,000"
             fill_in "client-assets-form-property-percentage-owned-field", with: "50"
             click_checkbox("client-assets-form-in-dispute", "property")
           end
@@ -215,8 +215,8 @@ RSpec.describe "Assets Page" do
           fill_in "client-assets-form-savings-field", with: "0"
           fill_in "client-assets-form-investments-field", with: "0"
           fill_in "client-assets-form-valuables-field", with: "0"
-          fill_in "client-assets-form-property-value-field", with: "80_000"
-          fill_in "client-assets-form-property-mortgage-field", with: "40_000"
+          fill_in "client-assets-form-property-value-field", with: "80,000"
+          fill_in "client-assets-form-property-mortgage-field", with: "40,000"
           fill_in "client-assets-form-property-percentage-owned-field", with: "50"
         end
       end

--- a/spec/features/dependant_details_page_spec.rb
+++ b/spec/features/dependant_details_page_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+VALID_INTEGER_VALUES = ["2", "2,000"].freeze
+INVALID_INTEGER_VALUES = ["two", "2 00", "2.37"].freeze
+
+RSpec.describe "Dependant details page" do
+  let(:dependant_details_header) { I18n.t("estimate_flow.dependant_details.legend") }
+
+  before do
+    visit_applicant_page
+    fill_in_applicant_screen_without_passporting_benefits
+    click_on "Save and continue"
+  end
+
+  VALID_INTEGER_VALUES.each do |value|
+    it "allows me to proceed if I enter '#{value}' as a value" do
+      select_boolean_value("dependant-details-form", :child_dependants, true)
+      select_boolean_value("dependant-details-form", :adult_dependants, false)
+      fill_in "dependant-details-form-child-dependants-count-field", with: value
+      click_on "Save and continue"
+      expect(page).not_to have_content(dependant_details_header)
+    end
+  end
+
+  INVALID_INTEGER_VALUES.each do |value|
+    it "does not allow me to proceed if I enter '#{value}' as a value" do
+      select_boolean_value("dependant-details-form", :child_dependants, true)
+      select_boolean_value("dependant-details-form", :adult_dependants, false)
+      fill_in "dependant-details-form-child-dependants-count-field", with: value
+      click_on "Save and continue"
+      expect(page).to have_content(dependant_details_header)
+      expect(page).to have_css(".govuk-error-summary__list")
+    end
+  end
+end

--- a/spec/features/employment_page_spec.rb
+++ b/spec/features/employment_page_spec.rb
@@ -80,6 +80,21 @@ RSpec.describe "Employment page" do
         end
       end
 
+      context "when I enter something invalid" do
+        before do
+          fill_in "employment-form-gross-income-field", with: "5,000"
+          fill_in "employment-form-income-tax-field", with: "1000"
+          fill_in "employment-form-national-insurance-field", with: "foo"
+          select_radio_value("employment-form", "frequency", "monthly")
+          click_on "Save and continue"
+        end
+
+        it "shows me an error message" do
+          expect(page).to have_content employment_page_header
+          expect(page).to have_content "There is a problem"
+        end
+      end
+
       context "when extering correct information" do
         before do
           fill_in "employment-form-gross-income-field", with: "5,000"

--- a/spec/features/employment_page_spec.rb
+++ b/spec/features/employment_page_spec.rb
@@ -91,7 +91,9 @@ RSpec.describe "Employment page" do
 
         it "shows me an error message" do
           expect(page).to have_content employment_page_header
-          expect(page).to have_content "There is a problem"
+          within ".govuk-error-summary__list" do
+            expect(page.text).to eq "National Insurance must be a number, if this does not apply enter 0"
+          end
         end
       end
 

--- a/spec/features/partner_assets_page_spec.rb
+++ b/spec/features/partner_assets_page_spec.rb
@@ -26,8 +26,8 @@ RSpec.describe "Partner assets page", :partner_flag do
       fill_in "partner-assets-form-savings-field", with: "0"
       fill_in "partner-assets-form-investments-field", with: "0"
       fill_in "partner-assets-form-valuables-field", with: "0"
-      fill_in "partner-assets-form-property-value-field", with: "80_000"
-      fill_in "partner-assets-form-property-mortgage-field", with: "40_000"
+      fill_in "partner-assets-form-property-value-field", with: "80,000"
+      fill_in "partner-assets-form-property-mortgage-field", with: "40,000"
       fill_in "partner-assets-form-property-percentage-owned-field", with: "50"
     end
 

--- a/spec/features/result_page_spec.rb
+++ b/spec/features/result_page_spec.rb
@@ -112,8 +112,8 @@ RSpec.describe "Results Page" do
           select_boolean_value("client-vehicle-details-form", :vehicle_pcp, true)
           fill_in "client-vehicle-details-form-vehicle-finance-field", with: 500
         when :assets
-          fill_in "client-assets-form-property-value-field", with: "80_000"
-          fill_in "client-assets-form-property-mortgage-field", with: "70_000"
+          fill_in "client-assets-form-property-value-field", with: "80,000"
+          fill_in "client-assets-form-property-mortgage-field", with: "70000"
           fill_in "client-assets-form-property-percentage-owned-field", with: "50"
 
           fill_in "client-assets-form-savings-field", with: "200"
@@ -221,8 +221,8 @@ RSpec.describe "Results Page" do
           select_boolean_value("partner-vehicle-details-form", :vehicle_pcp, true)
           fill_in "partner-vehicle-details-form-vehicle-finance-field", with: 500
         when :partner_assets
-          fill_in "partner-assets-form-property-value-field", with: "80_000"
-          fill_in "partner-assets-form-property-mortgage-field", with: "70_000"
+          fill_in "partner-assets-form-property-value-field", with: "80,000"
+          fill_in "partner-assets-form-property-mortgage-field", with: "70,000"
           fill_in "partner-assets-form-property-percentage-owned-field", with: "50"
 
           fill_in "partner-assets-form-savings-field", with: "200"


### PR DESCRIPTION
[Link to the Jira ticket](https://dsdmoj.atlassian.net/browse/EL-565)

- Allow users to enter non-number characters into integer input fields
- If the user enters something non-numeric into an integer or money field, retain the string value and use a `numericality` validation to flag its issues
- Display the original string value back to the user alongside the validation message if user-entered value is non-numeric