### PR TITLE
EL-558 Add approval step before production deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -258,10 +258,18 @@ workflows:
             branches:
               only:
                 - main
+      - deploy_production_approval:
+          type: approval
+          requires:
+            - build_and_push_to_ecr
+          filters:
+            branches:
+              only:
+                - main
       - deploy_production:
           context: laa-estimate-eligibility-production
           requires:
-            - build_and_push_to_ecr
+            - deploy_production_approval
           filters:
             branches:
               only:


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/EL-558

Add approval step before production deploy so that we can deploy to production out of hours in case it causes disruption