### PR TITLE
EL-569 Workaround for Puma/k8s dropped request problem

### DIFF
--- a/helm_deploy/laa-estimate-eligibility/templates/deployment.yaml
+++ b/helm_deploy/laa-estimate-eligibility/templates/deployment.yaml
@@ -40,3 +40,7 @@ spec:
             initialDelaySeconds: 30
           resources:
   {{ toYaml .Values.resources | indent 12 }}
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sh", "-c", "sleep 30"] # Workaround for occasional lost requests - see https://github.com/puma/puma/blob/master/docs/kubernetes.md#running-puma-in-kubernetes 


### PR DESCRIPTION
See: https://github.com/puma/puma/blob/master/docs/kubernetes.md#running-puma-in-kubernetes

[Link to the Jira ticket](https://dsdmoj.atlassian.net/browse/EL-569)

Describe what you did and why.

Added the sleep in preStop, to delay the point when Puma ignores incoming requests, so that it is definitely after the point when nginx stops sending it requests.

Checklist

Before you ask people to review this PR:

    Tests and rubocop should be passing
    Github should not be reporting conflicts; you should have recently run git rebase main.
    There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
    The PR description should say what you changed and why, with a link to the JIRA story.
    You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
    You should have checked that the commit messages say why the change was made.
