### PR TITLE
EL-575: Separate out headings from content in sidebar

### DIFF
--- a/app/views/shared/_sidebar_with_date.html.slim
+++ b/app/views/shared/_sidebar_with_date.html.slim
@@ -1,14 +1,12 @@
 = render "layouts/sidebar"
-  h2.govuk-body-m
-    strong = t("generic.date")
-    p.govuk-body-m = Date.current.strftime("%-d %B %Y")
+  h2.govuk-heading-s class="govuk-!-margin-bottom-0" = t("generic.date")
+  p.govuk-body-m = Date.current.strftime("%-d %B %Y")
 
   - if links.any?
-    h2.govuk-body-m
-      strong = t("generic.related_content_title")
-      - new_tab_text = t("generic.opens_in_new_tab")
-      ul class="govuk-list govuk-!-font-size-16"
-        - links.each do |text, dest|
-          li
-            p
-              = link_to "#{text} #{new_tab_text}", dest, target: "_blank", rel: "noreferrer noopener", class: "govuk-link govuk-body-m"
+    h2.govuk-heading-s class="govuk-!-margin-bottom-0 govuk-!-padding-top-0" = t("generic.related_content_title")
+    - new_tab_text = t("generic.opens_in_new_tab")
+    ul class="govuk-list govuk-!-font-size-16"
+      - links.each do |text, dest|
+        li
+          p
+            = link_to "#{text} #{new_tab_text}", dest, target: "_blank", rel: "noreferrer noopener", class: "govuk-link govuk-body-m"


### PR DESCRIPTION
[Link to the Jira ticket](https://dsdmoj.atlassian.net/browse/EL-575)

Make sure that the 'h2' element only contains the heading, not the content beneath it.
