### PR TITLE
EL-537: Add chart of error rate

### DIFF
--- a/infrastructure/laa-estimate-financial-eligibility-for-legal-aid-uat/ingress-dashboard.yaml
+++ b/infrastructure/laa-estimate-financial-eligibility-for-legal-aid-uat/ingress-dashboard.yaml
@@ -384,7 +384,7 @@ data:
                 "uid": "prometheus"
               },
               "editorMode": "code",
-              "expr": "sum by(status) (increase(nginx_ingress_controller_requests{exported_namespace=\"$namespace\", path!~\"/socket.io/.*\", ingress=\"$ingress\", status=~\"4..|5..\"}[5m]))/2",
+              "expr": "sum by(status) (increase(nginx_ingress_controller_requests{exported_namespace=\"$namespace\", path!~\"/socket.io/.*\", ingress=\"$ingress\", status=~\"4..|5..\"}[1m]))/2",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,

--- a/infrastructure/laa-estimate-financial-eligibility-for-legal-aid-uat/ingress-dashboard.yaml
+++ b/infrastructure/laa-estimate-financial-eligibility-for-legal-aid-uat/ingress-dashboard.yaml
@@ -350,6 +350,7 @@ data:
           },
           "hiddenSeries": false,
           "id": 7,
+          "interval": "1m",
           "legend": {
             "alignAsTable": false,
             "avg": false,
@@ -384,7 +385,7 @@ data:
                 "uid": "prometheus"
               },
               "editorMode": "code",
-              "expr": "sum by(status) (increase(nginx_ingress_controller_requests{exported_namespace=\"$namespace\", path!~\"/socket.io/.*\", ingress=\"$ingress\", status=~\"4..|5..\"}[1m]))/2",
+              "expr": "sum by(status) (increase(nginx_ingress_controller_requests{exported_namespace=\"$namespace\", path!~\"/socket.io/.*\", ingress=\"$ingress\", status=~\"4..|5..\"}[1m]))",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,

--- a/infrastructure/laa-estimate-financial-eligibility-for-legal-aid-uat/ingress-dashboard.yaml
+++ b/infrastructure/laa-estimate-financial-eligibility-for-legal-aid-uat/ingress-dashboard.yaml
@@ -349,6 +349,207 @@ data:
             "y": 30
           },
           "hiddenSeries": false,
+          "id": 7,
+          "legend": {
+            "alignAsTable": false,
+            "avg": false,
+            "current": true,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "9.2.4",
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": true,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "sum by(status) (rate(nginx_ingress_controller_requests{exported_namespace=\"$namespace\", path!~\"/socket.io/.*\", ingress=\"$ingress\", status=~\"4..|5..\"}[5m]))",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "",
+              "range": true,
+              "refId": "C",
+              "step": 30
+            }
+          ],
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "Request HTTP Errors",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "logBase": 1,
+              "show": true
+            },
+            {
+              "format": "short",
+              "logBase": 1,
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false
+          }
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "normal"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "links": [],
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 24,
+            "x": 0,
+            "y": 40
+          },
+          "id": 6,
+          "links": [],
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "displayMode": "list",
+              "placement": "right",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "9.2.4",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "sum by (phase) (kube_pod_status_phase{namespace=\"$namespace\",pod=~\"$ingress.*\"}) ",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "",
+              "range": true,
+              "refId": "C",
+              "step": 30
+            }
+          ],
+          "title": "Pod counts by status",
+          "type": "timeseries"
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "links": []
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 10,
+            "w": 24,
+            "x": 0,
+            "y": 50
+          },
+          "hiddenSeries": false,
           "id": 1,
           "legend": {
             "alignAsTable": false,
@@ -479,7 +680,7 @@ data:
               "refId": "Prometheus-namespace-Variable-Query"
             },
             "refresh": 1,
-            "regex": "/^laa-estimate-financial-eligibility-for-legal-aid-uat/",
+            "regex": "/^laa-estimate-financial-eligibility-for-legal-aid/",
             "skipUrlSync": false,
             "sort": 1,
             "tagValuesQuery": "",
@@ -549,6 +750,6 @@ data:
       "timezone": "browser",
       "title": "CCQ / Ingress (Check if your client qualifies for legal aid)",
       "uid": "djtEK4abc",
-      "version": 1,
+      "version": 3,
       "weekStart": ""
     }

--- a/infrastructure/laa-estimate-financial-eligibility-for-legal-aid-uat/ingress-dashboard.yaml
+++ b/infrastructure/laa-estimate-financial-eligibility-for-legal-aid-uat/ingress-dashboard.yaml
@@ -384,7 +384,7 @@ data:
                 "uid": "prometheus"
               },
               "editorMode": "code",
-              "expr": "sum by(status) (rate(nginx_ingress_controller_requests{exported_namespace=\"$namespace\", path!~\"/socket.io/.*\", ingress=\"$ingress\", status=~\"4..|5..\"}[5m]))",
+              "expr": "sum by(status) (increase(nginx_ingress_controller_requests{exported_namespace=\"$namespace\", path!~\"/socket.io/.*\", ingress=\"$ingress\", status=~\"4..|5..\"}[5m]))/2",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,


### PR DESCRIPTION
[Link to the Jira ticket](https://dsdmoj.atlassian.net/browse/EL-537

I took the currently live "Check if your client qualifies for legal aid - UAT - Ingress" dashboard in Grafana and duplicated the HTTP status requests chart. I renamed the duplicate to 'Request HTTP Errors' and filtered the data to include only 4XX and 5XX status codes. Then I exported the JSON and overwrote the JSON in ingress-dashboard.yml. Finally I checked the diff with what's on `main` and removed any extraneous changes. It looks like what's in main didn't include the `Pod counts by status` chart, so I've included the JSON for that as well.