### PR TITLE
EL-580 hide partner employment question when client is passported

### DIFF
--- a/app/forms/partner_details_form.rb
+++ b/app/forms/partner_details_form.rb
@@ -3,10 +3,26 @@ class PartnerDetailsForm
   include ActiveModel::Attributes
   include SessionPersistableForPartner
 
+  attr_accessor :passporting
+
   ATTRIBUTES = %i[over_60 employed].freeze
 
   ATTRIBUTES.each do |attr|
     attribute attr, :boolean
-    validates attr, inclusion: { in: [true, false] }
+    validates attr, inclusion: { in: [true, false] }, if: -> { !passporting || attr != :employed }
+  end
+
+  class << self
+    def from_session(session_data)
+      super(session_data).tap { set_extra_properties(_1, session_data) }
+    end
+
+    def from_params(params, session_data)
+      super(params, session_data).tap { set_extra_properties(_1, session_data) }
+    end
+
+    def set_extra_properties(form, session_data)
+      form.passporting = session_data["passporting"]
+    end
   end
 end

--- a/app/views/estimate_flow/partner_details.html.slim
+++ b/app/views/estimate_flow/partner_details.html.slim
@@ -26,9 +26,10 @@
             legend: { text: t(".partner_over_60.legend") },
             hint: { text: t(".partner_over_60.hint") }
 
-    = form.govuk_collection_radio_buttons :employed, employment_options, :first, :last,
-            legend: { text: t(".partner_employed.legend") },
-            hint: { text: t(".partner_employed.hint") }
+    - unless @estimate.passporting
+      = form.govuk_collection_radio_buttons :employed, employment_options, :first, :last,
+                  legend: { text: t(".partner_employed.legend") },
+                  hint: { text: t(".partner_employed.hint") }
 
     = form.govuk_submit t("generic.save_and_continue")
 = render "shared/sidebar_with_date", links: {}

--- a/spec/features/applicant_page_spec.rb
+++ b/spec/features/applicant_page_spec.rb
@@ -148,14 +148,12 @@ RSpec.describe "Applicant Page" do
         case step
         when :partner_details
           select_boolean_value("partner-details-form", :over_60, true)
-          select_boolean_value("partner-details-form", :employed, true)
         end
       end
 
       expect(page).to have_content I18n.t(".estimates.check_answers.partner_details")
       expect(page).to have_content "Has a partnerYes"
       expect(page).to have_content "Partner is over 60 years oldYes"
-      expect(page).to have_content "Partner is employedYes"
     end
   end
 

--- a/spec/features/property_page_spec.rb
+++ b/spec/features/property_page_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "Property Page" do
     context "without main client dwelling" do
       context "without dwelling" do
         before do
-          visit_check_answers(passporting: true, partner: true)
+          visit_check_answers(passporting: false, partner: true)
         end
 
         it "doesn't send a main dwelling" do
@@ -47,7 +47,7 @@ RSpec.describe "Property Page" do
 
           context "without a value" do
             before do
-              visit_flow_page(passporting: true, partner: true, target: :partner_property)
+              visit_flow_page(passporting: false, partner: true, target: :partner_property)
 
               select_radio_value("partner-property-form", "property-owned", "with_mortgage")
               click_on "Save and continue"
@@ -65,7 +65,7 @@ RSpec.describe "Property Page" do
 
           context "with a value" do
             before do
-              visit_check_answers(passporting: true, partner: true) do |step|
+              visit_check_answers(passporting: false, partner: true) do |step|
                 case step
                 when :partner_property
                   select_radio_value("partner-property-form", "property-owned", "with_mortgage")
@@ -101,7 +101,7 @@ RSpec.describe "Property Page" do
 
         context "without mortgage" do
           before do
-            visit_check_answers(passporting: true, partner: true) do |step|
+            visit_check_answers(passporting: false, partner: true) do |step|
               case step
               when :partner_property
                 select_radio_value("partner-property-form", "property-owned", "outright")
@@ -134,7 +134,7 @@ RSpec.describe "Property Page" do
         let(:expected_share) { 50 }
 
         before do
-          visit_check_answers(passporting: true, partner:) do |step|
+          visit_check_answers(passporting: false, partner:) do |step|
             case step
             when :property
               select_radio_value("property-form", "property-owned", "with_mortgage")
@@ -202,7 +202,7 @@ RSpec.describe "Property Page" do
         let(:expected_share) { 70 }
 
         before do
-          visit_check_answers(passporting: true, partner:) do |step|
+          visit_check_answers(passporting: false, partner:) do |step|
             case step
             when :property
               select_radio_value("property-form", "property-owned", "with_mortgage")


### PR DESCRIPTION
[Link to the Jira ticket](https://dsdmoj.atlassian.net/browse/EL-580)
Made the partner employment question conditional on the passporting question, update the validation to be flexible for the page.
Update tests

Checklist

Before you ask people to review this PR:

    Tests and rubocop should be passing
    Github should not be reporting conflicts; you should have recently run git rebase main.
    There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
    The PR description should say what you changed and why, with a link to the JIRA story.
    You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
    You should have checked that the commit messages say why the change was made.


[EL-580]: https://dsdmoj.atlassian.net/browse/EL-580?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ