### PR TITLE
Parallelise ECR push step to save 1min 30sec during deployment testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,6 @@ references:
         echo "${GIT_CRYPT_KEY}" | base64 -d > git-crypt.key
         git-crypt unlock git-crypt.key
 
-
 orbs:
   browser-tools: circleci/browser-tools@1.4.0
 
@@ -232,11 +231,12 @@ workflows:
             - install_dependencies
       - build_and_push_to_ecr:
           requires:
-            - run_specs
-            - linters
+            - install_dependencies
       - deploy_uat:
           context: laa-estimate-eligibility-uat
           requires:
+            - linters
+            - run_specs
             - build_and_push_to_ecr
 
   merge_pr_to_main:
@@ -253,16 +253,19 @@ workflows:
             - install_dependencies
       - build_and_push_to_ecr:
           requires:
-            - run_specs
-            - linters
+            - install_dependencies
       - deploy_uat:
           name: deploy_main_uat
           context: laa-estimate-eligibility-uat
           requires:
+            - run_specs
+            - linters
             - build_and_push_to_ecr
       - deploy_staging:
           context: laa-estimate-eligibility-staging
           requires:
+            - run_specs
+            - linters
             - build_and_push_to_ecr
           filters:
             branches:
@@ -271,6 +274,8 @@ workflows:
       - deploy_production_approval:
           type: approval
           requires:
+            - run_specs
+            - linters
             - build_and_push_to_ecr
           filters:
             branches:


### PR DESCRIPTION
## What changed and why

The sequential ECR push step in circle slows down testing of our deployment issues - this makes it parallel so that we can deploy quicker. It also brings us in line with the Circle:CI flow used by apply
