### PR TITLE
EL-607 fix crash when submitting a partner during a passported application

### DIFF
--- a/app/services/submit_partner_service.rb
+++ b/app/services/submit_partner_service.rb
@@ -32,10 +32,12 @@ class SubmitPartnerService < BaseCfeService
   end
 
   def employments
-    return [] unless partner[:employed] && !@applicant_form.passporting
-
-    form = PartnerEmploymentForm.from_session(@cfe_session_data)
-    CfeParamBuilders::Employments.call(form)
+    if partner[:employed] && !@applicant_form.passporting
+      form = PartnerEmploymentForm.from_session(@cfe_session_data)
+      CfeParamBuilders::Employments.call(form)
+    else
+      []
+    end
   end
 
   def regular_transactions

--- a/app/services/submit_partner_service.rb
+++ b/app/services/submit_partner_service.rb
@@ -21,7 +21,7 @@ class SubmitPartnerService < BaseCfeService
       form = PartnerDetailsForm.from_session(@cfe_session_data)
       {
         date_of_birth: form.over_60 ? 70.years.ago.to_date : 50.years.ago.to_date,
-        employed: form.employed,
+        employed: form.employed || false,
       }
     end
   end

--- a/spec/fixtures/vcr_cassettes/Partner_with_passporting/CFE_submission/handles_can_submit_to_CFE.yml
+++ b/spec/fixtures/vcr_cassettes/Partner_with_passporting/CFE_submission/handles_can_submit_to_CFE.yml
@@ -1,0 +1,271 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://check-financial-eligibility-partner-staging.cloud-platform.service.justice.gov.uk/assessments
+    body:
+      encoding: UTF-8
+      string: '{"submission_date":"2022-09-05"}'
+    headers:
+      Accept:
+      - application/json;version=5
+      User-Agent:
+      - Faraday v2.7.2
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      date:
+      - Tue, 10 Jan 2023 14:32:10 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - keep-alive
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-permitted-cross-domain-policies:
+      - none
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      vary:
+      - Accept
+      etag:
+      - W/"e1bdb72a0356696fb2011a860183eb90"
+      cache-control:
+      - max-age=0, private, must-revalidate
+      x-request-id:
+      - 203e38e9c7f95efbb6d8560bb0dd2b24
+      x-runtime:
+      - '0.045901'
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '{"success":true,"assessment_id":"38543f19-7296-4987-9e2e-199e68ecd399","errors":[]}'
+  recorded_at: Mon, 05 Sep 2022 09:00:00 GMT
+- request:
+    method: post
+    uri: https://check-financial-eligibility-partner-staging.cloud-platform.service.justice.gov.uk/assessments/38543f19-7296-4987-9e2e-199e68ecd399/proceeding_types
+    body:
+      encoding: UTF-8
+      string: '{"proceeding_types":[{"ccms_code":"SE003","client_involvement_type":"A"}]}'
+    headers:
+      Accept:
+      - application/json;version=5
+      User-Agent:
+      - Faraday v2.7.2
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      date:
+      - Tue, 10 Jan 2023 14:32:10 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - keep-alive
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-permitted-cross-domain-policies:
+      - none
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      vary:
+      - Accept
+      etag:
+      - W/"e156c1de751f0fc41f3ce5edefd256d2"
+      cache-control:
+      - max-age=0, private, must-revalidate
+      x-request-id:
+      - 998f3eb62e122afaefab711325ade07e
+      x-runtime:
+      - '0.025250'
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '{"success":true,"errors":[]}'
+  recorded_at: Mon, 05 Sep 2022 09:00:00 GMT
+- request:
+    method: post
+    uri: https://check-financial-eligibility-partner-staging.cloud-platform.service.justice.gov.uk/assessments/38543f19-7296-4987-9e2e-199e68ecd399/applicant
+    body:
+      encoding: UTF-8
+      string: '{"applicant":{"date_of_birth":"1972-09-05","has_partner_opponent":false,"receives_qualifying_benefit":true,"employed":false}}'
+    headers:
+      Accept:
+      - application/json;version=5
+      User-Agent:
+      - Faraday v2.7.2
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      date:
+      - Tue, 10 Jan 2023 14:32:10 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - keep-alive
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-permitted-cross-domain-policies:
+      - none
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      vary:
+      - Accept
+      etag:
+      - W/"e156c1de751f0fc41f3ce5edefd256d2"
+      cache-control:
+      - max-age=0, private, must-revalidate
+      x-request-id:
+      - 578c675e5d77570d2dd57bcb7d53bcca
+      x-runtime:
+      - '0.027746'
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '{"success":true,"errors":[]}'
+  recorded_at: Mon, 05 Sep 2022 09:00:00 GMT
+- request:
+    method: post
+    uri: https://check-financial-eligibility-partner-staging.cloud-platform.service.justice.gov.uk/assessments/38543f19-7296-4987-9e2e-199e68ecd399/partner_financials
+    body:
+      encoding: UTF-8
+      string: '{"partner":{"date_of_birth":"1972-09-05","employed":false},"irregular_incomes":[],"employments":[],"regular_transactions":[],"state_benefits":[],"additional_properties":[],"capitals":{"bank_accounts":[],"non_liquid_capital":[]},"dependants":[],"vehicles":[]}'
+    headers:
+      Accept:
+      - application/json;version=5
+      User-Agent:
+      - Faraday v2.7.2
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      date:
+      - Tue, 10 Jan 2023 14:32:10 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - keep-alive
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-permitted-cross-domain-policies:
+      - none
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      vary:
+      - Accept
+      etag:
+      - W/"e156c1de751f0fc41f3ce5edefd256d2"
+      cache-control:
+      - max-age=0, private, must-revalidate
+      x-request-id:
+      - 05a6ac7259c50de9180f4cedc0c609f1
+      x-runtime:
+      - '0.058052'
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '{"success":true,"errors":[]}'
+  recorded_at: Mon, 05 Sep 2022 09:00:00 GMT
+- request:
+    method: get
+    uri: https://check-financial-eligibility-partner-staging.cloud-platform.service.justice.gov.uk/assessments/38543f19-7296-4987-9e2e-199e68ecd399
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json;version=5
+      User-Agent:
+      - Faraday v2.7.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      date:
+      - Tue, 10 Jan 2023 14:32:10 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - keep-alive
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-permitted-cross-domain-policies:
+      - none
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      vary:
+      - Accept
+      etag:
+      - W/"2b2752d681da64d6524370d1cdf5305b"
+      cache-control:
+      - max-age=0, private, must-revalidate
+      x-request-id:
+      - 1aa69985d58f0c8f4cafb433b877ef17
+      x-runtime:
+      - '0.352910'
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '{"version":"5","timestamp":"2023-01-10T14:32:10.793Z","success":true,"result_summary":{"overall_result":{"result":"eligible","capital_contribution":0.0,"income_contribution":0.0,"proceeding_types":[{"ccms_code":"SE003","client_involvement_type":"A","upper_threshold":0.0,"lower_threshold":0.0,"result":"eligible"}]},"gross_income":{"total_gross_income":0.0,"proceeding_types":[{"ccms_code":"SE003","client_involvement_type":"A","upper_threshold":2657.0,"lower_threshold":0.0,"result":"pending"}],"combined_total_gross_income":0.0},"partner_gross_income":{"total_gross_income":0.0},"disposable_income":{"dependant_allowance":0.0,"gross_housing_costs":0.0,"housing_benefit":0.0,"net_housing_costs":0.0,"maintenance_allowance":0.0,"total_outgoings_and_allowances":0.0,"total_disposable_income":0.0,"employment_income":{"gross_income":0.0,"benefits_in_kind":0.0,"tax":0.0,"national_insurance":0.0,"fixed_employment_deduction":0.0,"net_employment_income":0.0},"income_contribution":0.0,"proceeding_types":[{"ccms_code":"SE003","client_involvement_type":"A","upper_threshold":733.0,"lower_threshold":315.0,"result":"pending"}],"combined_total_disposable_income":0.0,"combined_total_outgoings_and_allowances":0.0},"partner_disposable_income":{"dependant_allowance":0.0,"gross_housing_costs":0.0,"housing_benefit":0.0,"net_housing_costs":0.0,"maintenance_allowance":0.0,"total_outgoings_and_allowances":0.0,"total_disposable_income":0.0,"employment_income":{"gross_income":0.0,"benefits_in_kind":0.0,"tax":0.0,"national_insurance":0.0,"fixed_employment_deduction":0.0,"net_employment_income":0.0},"income_contribution":0.0,"partner_allowance":191.41},"capital":{"total_liquid":0.0,"total_non_liquid":0.0,"total_vehicle":0.0,"total_property":0.0,"total_mortgage_allowance":999999999999.0,"total_capital":0.0,"pensioner_capital_disregard":0.0,"subject_matter_of_dispute_disregard":0.0,"capital_contribution":0.0,"assessed_capital":0.0,"proceeding_types":[{"ccms_code":"SE003","client_involvement_type":"A","upper_threshold":8000.0,"lower_threshold":3000.0,"result":"eligible"}],"combined_assessed_capital":0.0,"combined_capital_contribution":0.0},"partner_capital":{"total_liquid":0.0,"total_non_liquid":0.0,"total_vehicle":0.0,"total_property":0.0,"total_mortgage_allowance":999999999999.0,"total_capital":0.0,"pensioner_capital_disregard":0.0,"subject_matter_of_dispute_disregard":0.0,"capital_contribution":0.0,"assessed_capital":0.0}},"assessment":{"id":"38543f19-7296-4987-9e2e-199e68ecd399","client_reference_id":null,"submission_date":"2022-09-05","applicant":{"date_of_birth":"1972-09-05","involvement_type":null,"employed":false,"has_partner_opponent":false,"receives_qualifying_benefit":true,"self_employed":false},"gross_income":{"employment_income":[],"irregular_income":{"monthly_equivalents":{"student_loan":0.0,"unspecified_source":0.0}},"state_benefits":{"monthly_equivalents":{"all_sources":0.0,"cash_transactions":0.0,"bank_transactions":[]}},"other_income":{"monthly_equivalents":{"all_sources":{"friends_or_family":0.0,"maintenance_in":0.0,"property_or_lodger":0.0,"pension":0.0},"bank_transactions":{"friends_or_family":0.0,"maintenance_in":0.0,"property_or_lodger":0.0,"pension":0.0},"cash_transactions":{"friends_or_family":0.0,"maintenance_in":0.0,"property_or_lodger":0.0,"pension":0.0}}}},"partner_gross_income":{"employment_income":[],"irregular_income":{"monthly_equivalents":{"student_loan":0.0,"unspecified_source":0.0}},"state_benefits":{"monthly_equivalents":{"all_sources":0.0,"cash_transactions":0.0,"bank_transactions":[]}},"other_income":{"monthly_equivalents":{"all_sources":{"friends_or_family":0.0,"maintenance_in":0.0,"property_or_lodger":0.0,"pension":0.0},"bank_transactions":{"friends_or_family":0.0,"maintenance_in":0.0,"property_or_lodger":0.0,"pension":0.0},"cash_transactions":{"friends_or_family":0.0,"maintenance_in":0.0,"property_or_lodger":0.0,"pension":0.0}}}},"disposable_income":{"monthly_equivalents":{"all_sources":{"child_care":0.0,"rent_or_mortgage":0.0,"maintenance_out":0.0,"legal_aid":0.0},"bank_transactions":{"child_care":0.0,"rent_or_mortgage":0.0,"maintenance_out":0.0,"legal_aid":0.0},"cash_transactions":{"child_care":0.0,"rent_or_mortgage":0.0,"maintenance_out":0.0,"legal_aid":0.0}},"childcare_allowance":0.0,"deductions":{"dependants_allowance":0.0,"disregarded_state_benefits":0.0}},"partner_disposable_income":{"monthly_equivalents":{"all_sources":{"child_care":0.0,"rent_or_mortgage":0.0,"maintenance_out":0.0,"legal_aid":0.0},"bank_transactions":{"child_care":0.0,"rent_or_mortgage":0.0,"maintenance_out":0.0,"legal_aid":0.0},"cash_transactions":{"child_care":0.0,"rent_or_mortgage":0.0,"maintenance_out":0.0,"legal_aid":0.0}},"childcare_allowance":0.0,"deductions":{"dependants_allowance":0.0,"disregarded_state_benefits":0.0}},"capital":{"capital_items":{"liquid":[],"non_liquid":[],"vehicles":[],"properties":{"main_home":null,"additional_properties":[]}}},"partner_capital":{"capital_items":{"liquid":[],"non_liquid":[],"vehicles":[],"properties":{"main_home":null,"additional_properties":[]}}},"remarks":{}}}'
+  recorded_at: Mon, 05 Sep 2022 09:00:00 GMT
+recorded_with: VCR 6.1.0

--- a/spec/support/navigation_helpers.rb
+++ b/spec/support/navigation_helpers.rb
@@ -96,6 +96,12 @@ PARTNER_HANDLERS = {
   },
 }.freeze
 
+PARTNER_PASSPORTED_HANDLERS = {
+  partner_details: lambda { |page:|
+    select_boolean(page:, form_name: "partner-details-form", field: :over_60, value: false)
+  },
+}.freeze
+
 PARTNER_INCOME_HANDLERS = {
   partner_dependants: lambda { |page:|
     select_boolean(page:, form_name: "partner-dependant-details-form", field: :child_dependants, value: false)
@@ -163,7 +169,8 @@ def visit_flow_page(passporting:, target:, partner: false, &block)
   return unless process_handler_group(CAPITAL_HANDLERS, target, &block)
 
   if partner
-    return unless process_handler_group(PARTNER_HANDLERS, target, &block)
+    partner_group = passporting ? PARTNER_PASSPORTED_HANDLERS : PARTNER_HANDLERS
+    return unless process_handler_group(partner_group, target, &block)
 
     if !passporting && !process_handler_group(PARTNER_INCOME_HANDLERS, target, &block)
       return

--- a/spec/system/partner_passporting_spec.rb
+++ b/spec/system/partner_passporting_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.describe "Partner with passporting", :vcr, :partner_flag do
+  let(:arbitrary_fixed_time) { Time.zone.local(2022, 9, 5, 9, 0, 0) }
+
+  before do
+    travel_to arbitrary_fixed_time
+  end
+
+  describe "CFE submission" do
+    before do
+      driven_by(:headless_chrome)
+      visit_check_answers(passporting: true, partner: true)
+    end
+
+    it "handles can submit to CFE" do
+      click_on "Submit"
+
+      expect(page).to have_content "Your client appears provisionally eligible"
+    end
+  end
+end


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/EL-607

## What changed and why

When filling in a passported application with a partner, the 'employed' question is never asked of the partner, so the 'employed' field was nil rather than false. This upset CFE which wanted true/false only. This fixes this so we only send true or false during this process