### PR TITLE
Decision doesn't need to be defaulted 

### DIFF
--- a/app/models/calculation_result.rb
+++ b/app/models/calculation_result.rb
@@ -11,7 +11,7 @@ class CalculationResult
   end
 
   def decision
-    api_response.dig(:result_summary, :overall_result, :result) || "ineligible"
+    api_response.dig(:result_summary, :overall_result, :result)
   end
 
   # Note - this is probably technically incorrect as partially eligible could mean


### PR DESCRIPTION
decision it is always present in the API response, so it doesn't need to be defaulted.

It is worth noting that the style a = something || 0 doesn't get caught by the coverage tools - the || 0 is not considered a branch.