### PR TITLE
Deja vu? New guidance links on applicant and dependant pages

### DIFF
--- a/app/views/estimate_flow/applicant.html.slim
+++ b/app/views/estimate_flow/applicant.html.slim
@@ -74,13 +74,13 @@
 - if @form.level_of_help == "controlled"
   = render "shared/sidebar_with_date", \
            links: { \
-             t(".passporting_guidance.text") => t(".passporting_guidance.link"), \
-             t(".pensioner_guidance.text") => t(".pensioner_guidance.link"),
+             t(".passporting_guidance.text") => t(".passporting_guidance.controlled_link"), \
+             t(".pensioner_guidance.text") => t(".pensioner_guidance.controlled_link"),
            }
 - else
   = render "shared/sidebar_with_date", \
            links: { \
-             t(".passporting_guidance.text") => t(".passporting_guidance.link"), \
-             t(".pensioner_guidance.text") => t(".pensioner_guidance.link"), \
+             t(".passporting_guidance.text") => t(".passporting_guidance.certificated_link"), \
+             t(".pensioner_guidance.text") => t(".pensioner_guidance.certificated_link"), \
              t(".domestic_abuse_guidance.text") => t(".domestic_abuse_guidance.link"),
            }

--- a/app/views/estimate_flow/dependant_details.html.slim
+++ b/app/views/estimate_flow/dependant_details.html.slim
@@ -6,5 +6,9 @@
 .govuk-grid-column-two-thirds
   = render "estimate_flow/forms/dependant_details", i18n_key: :dependant_details
 
-= render "shared/sidebar_with_date",
-         links: { t("estimate_flow.dependant_details.guidance.text") => t("estimate_flow.dependant_details.guidance.link") }
+- if @estimate.level_of_help == "controlled"
+  = render "shared/sidebar_with_date",
+          links: { t("estimate_flow.dependant_details.guidance.text") => t("estimate_flow.dependant_details.guidance.controlled_link") }
+- else
+  = render "shared/sidebar_with_date",
+          links: { t("estimate_flow.dependant_details.guidance.text") => t("estimate_flow.dependant_details.guidance.certificated_link") }

--- a/app/views/estimate_flow/partner_dependant_details.html.slim
+++ b/app/views/estimate_flow/partner_dependant_details.html.slim
@@ -6,5 +6,9 @@
 .govuk-grid-column-two-thirds
   = render "estimate_flow/forms/dependant_details", i18n_key: :partner_dependant_details
 
-= render "shared/sidebar_with_date",
-         links: { t("estimate_flow.dependant_details.guidance.text") => t("estimate_flow.dependant_details.guidance.link") }
+- if @estimate.level_of_help == "controlled"
+  = render "shared/sidebar_with_date",
+          links: { t("estimate_flow.dependant_details.guidance.text") => t("estimate_flow.dependant_details.guidance.controlled_link") }
+- else
+  = render "shared/sidebar_with_date",
+          links: { t("estimate_flow.dependant_details.guidance.text") => t("estimate_flow.dependant_details.guidance.certificated_link") }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -491,10 +491,12 @@ en:
     applicant:
       passporting_guidance:
         text: Guidance on passporting
-        link: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/1045682/Lord_Chancellor_s_guidance_on.pdf#page=11
+        certificated_link: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/1045682/Lord_Chancellor_s_guidance_on.pdf#page=11
+        controlled_link: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/983065/Lord_Chancellor_s_guidance_on_determining_controlled_work_and_family_mediation.pdf#page=5
       pensioner_guidance:
         text: "Guidance on Pensioner disregards"
-        link: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/1045682/Lord_Chancellor_s_guidance_on.pdf#page=71
+        certificated_link: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/1045682/Lord_Chancellor_s_guidance_on.pdf#page=71
+        controlled_link: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/983065/Lord_Chancellor_s_guidance_on_determining_controlled_work_and_family_mediation.pdf#page=29
       heading: Tell us about your client
       caption: About your client
       partner:
@@ -594,7 +596,8 @@ en:
         - can be an adult or a child
       guidance:
         text: Guidance on dependants
-        link: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/1045682/Lord_Chancellor_s_guidance_on.pdf#page=42
+        certificated_link: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/1045682/Lord_Chancellor_s_guidance_on.pdf#page=42
+        controlled_link: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/983065/Lord_Chancellor_s_guidance_on_determining_controlled_work_and_family_mediation.pdf#page=15
     partner_dependant_details:
       caption: About the partner
       legend: The partner's dependants


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-669)

## What changed and why

[Original PR](https://github.com/ministryofjustice/laa-estimate-financial-eligibility-for-legal-aid/pull/395). I merged this into the wrong place and then force pushed in the wrong place and lost this change

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
