### PR TITLE
EL-709: De-identify user in logs

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,28 +4,32 @@ class ApplicationController < ActionController::Base
 
 private
 
-  def session_data(id = estimate_id)
-    session[session_key(id)] ||= {}
+  def assessment_id
+    Digest::SHA256.hexdigest(assessment_code + (cookies["SessionData"] || ""))
   end
 
-  def session_key(id)
-    "estimate_#{id}"
+  def session_data
+    session[assessment_id] ||= {}
   end
 
-  def track_page_view(assessment_id: nil, page: page_name)
-    track("page_view", assessment_id:, page:)
+  def track_page_view(page: page_name)
+    track("page_view", page:)
   end
 
-  def track_validation_error(assessment_id: nil, page: page_name)
-    track("validation_message", assessment_id:, page:)
-    track_page_view(assessment_id:, page:)
+  def track_validation_error(page: page_name)
+    track("validation_message", page:)
+    track_page_view(page:)
   end
 
-  def track(event_type, assessment_id:, page:)
+  def track(event_type, page:)
     AnalyticsService.call(event_type:,
                           browser_id: cookies[BROWSER_ID_COOKIE],
-                          assessment_id:,
+                          assessment_code:,
                           page:)
+  end
+
+  def assessment_code
+    nil
   end
 
   def page_name

--- a/app/controllers/benefits_controller.rb
+++ b/app/controllers/benefits_controller.rb
@@ -4,7 +4,7 @@ class BenefitsController < EstimateFlowController
   def new
     @model = model_class.new
     @estimate = load_estimate
-    track_page_view(assessment_id: estimate_id)
+    track_page_view
   end
 
   def create
@@ -16,7 +16,7 @@ class BenefitsController < EstimateFlowController
       session_data[benefit_session_key] << @model.attributes
       redirect_to flow_path(step_name)
     else
-      track_validation_error(assessment_id: estimate_id)
+      track_validation_error
       render :new
     end
   end
@@ -25,7 +25,7 @@ class BenefitsController < EstimateFlowController
     @estimate = load_estimate
     benefit_attributes = session_data[benefit_session_key].find { _1["id"] == params[:id] }
     @model = model_class.new(benefit_attributes)
-    track_page_view(assessment_id: estimate_id)
+    track_page_view
   end
 
   def update
@@ -38,7 +38,7 @@ class BenefitsController < EstimateFlowController
       session_data[benefit_session_key][index] = @model.attributes
       redirect_to flow_path(step_name)
     else
-      track_validation_error(assessment_id: estimate_id)
+      track_validation_error
       render :edit
     end
   end
@@ -59,7 +59,7 @@ class BenefitsController < EstimateFlowController
         redirect_to next_step_path @estimate
       end
     else
-      track_validation_error(assessment_id: estimate_id)
+      track_validation_error
       render "estimate_flow/#{step_name}"
     end
   end
@@ -79,11 +79,11 @@ private
   end
 
   def flow_path(step)
-    estimate_build_estimate_path estimate_id, step
+    estimate_build_estimate_path assessment_code, step
   end
 
   def new_path
-    new_estimate_benefit_path(estimate_id)
+    new_estimate_benefit_path(assessment_code)
   end
 
   def next_step_path(model)

--- a/app/controllers/build_estimates_controller.rb
+++ b/app/controllers/build_estimates_controller.rb
@@ -1,6 +1,4 @@
 class BuildEstimatesController < EstimateFlowController
-  before_action :load_estimate_id
-
   def update
     @form = Flow::Handler.model_from_params(step, params, session_data)
 
@@ -16,18 +14,12 @@ class BuildEstimatesController < EstimateFlowController
       end
     else
       @estimate = load_estimate
-      track_validation_error(assessment_id: estimate_id)
+      track_validation_error
       render_wizard
     end
   end
 
   def finish_wizard_path
-    check_answers_estimate_path @estimate_id
-  end
-
-private
-
-  def load_estimate_id
-    @estimate_id = params[:estimate_id]
+    check_answers_estimate_path assessment_code
   end
 end

--- a/app/controllers/check_answers_controller.rb
+++ b/app/controllers/check_answers_controller.rb
@@ -12,13 +12,13 @@ class CheckAnswersController < EstimateFlowController
         if next_step
           redirect_to wizard_path next_step
         else
-          redirect_to check_answers_estimate_path(estimate_id, anchor:)
+          redirect_to check_answers_estimate_path(assessment_code, anchor:)
         end
       else
         redirect_to wizard_path StepsHelper.next_step_for(estimate, step)
       end
     else
-      track_validation_error(assessment_id: estimate_id)
+      track_validation_error
       @estimate = load_estimate
       render "estimate_flow/#{step}"
     end

--- a/app/controllers/check_benefits_answers_controller.rb
+++ b/app/controllers/check_benefits_answers_controller.rb
@@ -2,11 +2,11 @@ class CheckBenefitsAnswersController < BenefitsController
 private
 
   def flow_path(step)
-    estimate_check_answer_path estimate_id, step
+    estimate_check_answer_path assessment_code, step
   end
 
   def new_path
-    new_estimate_check_benefits_answer_path(estimate_id)
+    new_estimate_check_benefits_answer_path(assessment_code)
   end
 
   def next_step_path(model)
@@ -14,7 +14,7 @@ private
     if next_step.present?
       flow_path next_step
     else
-      check_answers_estimate_path estimate_id, anchor:
+      check_answers_estimate_path assessment_code, anchor:
     end
   end
 

--- a/app/controllers/check_partner_benefits_answers_controller.rb
+++ b/app/controllers/check_partner_benefits_answers_controller.rb
@@ -2,7 +2,7 @@ class CheckPartnerBenefitsAnswersController < CheckBenefitsAnswersController
 private
 
   def new_path
-    new_estimate_check_partner_benefits_answer_path(estimate_id)
+    new_estimate_check_partner_benefits_answer_path(assessment_code)
   end
 
   def post_destroy_path

--- a/app/controllers/estimate_flow_controller.rb
+++ b/app/controllers/estimate_flow_controller.rb
@@ -4,7 +4,7 @@ class EstimateFlowController < ApplicationController
   steps(*StepsHelper.all_possible_steps)
 
   def show
-    track_page_view(assessment_id: estimate_id)
+    track_page_view
     @form = Flow::Handler.model_from_session(step, session_data)
     @estimate = load_estimate
     render_wizard
@@ -16,16 +16,8 @@ protected
     EstimateModel.from_session(session_data)
   end
 
-  def estimate_id
+  def assessment_code
     params[:estimate_id]
-  end
-
-  def session_data
-    session[session_key] ||= {}
-  end
-
-  def session_key
-    "estimate_#{estimate_id}"
   end
 
   def next_check_answer_step(step, model)

--- a/app/controllers/estimates_controller.rb
+++ b/app/controllers/estimates_controller.rb
@@ -4,12 +4,9 @@ class EstimatesController < ApplicationController
   end
 
   def create
-    redirect_to estimate_path(params[:estimate_id])
-  end
-
-  def show
     @model = CfeService.call(session_data)
     track_page_view(page: :view_results)
+    render :show
   end
 
   def print
@@ -26,13 +23,11 @@ class EstimatesController < ApplicationController
 
   def download
     track_page_view(page: :download_results)
+    @model = CfeService.call(session_data)
+    @answers = CheckAnswersPresenter.new(session_data)
     html = render_to_string({
       template: "estimates/print",
       layout: "print_application",
-      locals: {
-        :@model => CfeService.call(session_data),
-        :@answers => CheckAnswersPresenter.new(session_data),
-      },
     })
 
     grover_options = {

--- a/app/controllers/estimates_controller.rb
+++ b/app/controllers/estimates_controller.rb
@@ -4,32 +4,34 @@ class EstimatesController < ApplicationController
   end
 
   def create
-    @model = CfeService.call(cfe_session_data(:estimate_id))
-    track_page_view(assessment_id: params[:estimate_id], page: :view_results)
-    render :show
+    redirect_to estimate_path(params[:estimate_id])
+  end
+
+  def show
+    @model = CfeService.call(session_data)
+    track_page_view(page: :view_results)
   end
 
   def print
-    @model = CfeService.call(cfe_session_data(:id))
-    @answers = CheckAnswersPresenter.new cfe_session_data(:id)
-    track_page_view(assessment_id: params[:id], page: :print_results)
+    @model = CfeService.call(session_data)
+    @answers = CheckAnswersPresenter.new session_data
+    track_page_view(page: :print_results)
     render :print, layout: "print_application"
   end
 
   def check_answers
-    @answers = CheckAnswersPresenter.new cfe_session_data(:id)
-    @estimate_id = params.fetch(:id)
-    track_page_view(assessment_id: @estimate_id, page: :check_answers)
+    @answers = CheckAnswersPresenter.new session_data
+    track_page_view(page: :check_answers)
   end
 
   def download
-    track_page_view(assessment_id: params[:id], page: :download_results)
+    track_page_view(page: :download_results)
     html = render_to_string({
       template: "estimates/print",
       layout: "print_application",
       locals: {
-        :@model => CfeService.call(cfe_session_data(:id)),
-        :@answers => CheckAnswersPresenter.new(cfe_session_data(:id)),
+        :@model => CfeService.call(session_data),
+        :@answers => CheckAnswersPresenter.new(session_data),
       },
     })
 
@@ -55,7 +57,7 @@ class EstimatesController < ApplicationController
 
 private
 
-  def cfe_session_data(param_name)
-    session_data params[param_name]
+  def assessment_code
+    params[:id]
   end
 end

--- a/app/controllers/partner_benefits_controller.rb
+++ b/app/controllers/partner_benefits_controller.rb
@@ -14,6 +14,6 @@ private
   end
 
   def new_path
-    new_estimate_partner_benefit_path(estimate_id)
+    new_estimate_partner_benefit_path(assessment_code)
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -45,11 +45,11 @@ module ApplicationHelper
     link_to t("generic.back"), link, class: "govuk-back-link"
   end
 
-  def flow_path(estimate_id, step, check_answers: false)
+  def flow_path(assessment_code, step, check_answers: false)
     if check_answers
-      estimate_check_answer_path(estimate_id, step)
+      estimate_check_answer_path(assessment_code, step)
     else
-      estimate_build_estimate_path(estimate_id, step)
+      estimate_build_estimate_path(assessment_code, step)
     end
   end
 end

--- a/app/services/analytics_service.rb
+++ b/app/services/analytics_service.rb
@@ -1,6 +1,6 @@
 class AnalyticsService
   class << self
-    def call(event_type:, page:, assessment_code: nil, browser_id: nil)
+    def call(event_type:, page:, assessment_code:, browser_id:)
       hash = {
         key: "CCQ Analytics Datum",
         event_type:,

--- a/app/services/analytics_service.rb
+++ b/app/services/analytics_service.rb
@@ -1,11 +1,11 @@
 class AnalyticsService
   class << self
-    def call(event_type:, page:, assessment_id: nil, browser_id: nil)
+    def call(event_type:, page:, assessment_code: nil, browser_id: nil)
       hash = {
         key: "CCQ Analytics Datum",
         event_type:,
         page:,
-        assessment_id:,
+        assessment_code:,
         browser_id:,
       }
       Rails.logger.info hash.to_json

--- a/app/services/base_cfe_service.rb
+++ b/app/services/base_cfe_service.rb
@@ -1,6 +1,6 @@
 class BaseCfeService
-  def self.call(cfe_connection, cfe_estimate_id, cfe_session_data)
-    new(cfe_connection).call(cfe_estimate_id, cfe_session_data)
+  def self.call(cfe_connection, cfe_assessment_id, session_data)
+    new(cfe_connection).call(cfe_assessment_id, session_data)
   end
 
   def initialize(cfe_connection)

--- a/app/services/cfe_service.rb
+++ b/app/services/cfe_service.rb
@@ -1,19 +1,19 @@
 class CfeService
   class << self
-    def call(cfe_session_data)
+    def call(session_data)
       cfe_connection = CfeConnection.connection
-      cfe_estimate_id = create_assessment_id(cfe_connection, cfe_session_data)
-      SubmitDependantsService.call(cfe_connection, cfe_estimate_id, cfe_session_data)
-      SubmitProceedingsService.call(cfe_connection, cfe_estimate_id, cfe_session_data)
-      SubmitEmploymentIncomeService.call(cfe_connection, cfe_estimate_id, cfe_session_data)
-      SubmitBenefitsService.call(cfe_connection, cfe_estimate_id, cfe_session_data)
-      SubmitIrregularIncomeService.call(cfe_connection, cfe_estimate_id, cfe_session_data)
-      SubmitVehicleService.call(cfe_connection, cfe_estimate_id, cfe_session_data)
-      SubmitAssetsService.call(cfe_connection, cfe_estimate_id, cfe_session_data)
-      SubmitRegularTransactionsService.call(cfe_connection, cfe_estimate_id, cfe_session_data)
-      SubmitApplicantService.call(cfe_connection, cfe_estimate_id, cfe_session_data)
-      SubmitPartnerService.call(cfe_connection, cfe_estimate_id, cfe_session_data)
-      result(cfe_connection, cfe_estimate_id, cfe_session_data)
+      cfe_assessment_id = create_assessment_id(cfe_connection, session_data)
+      SubmitDependantsService.call(cfe_connection, cfe_assessment_id, session_data)
+      SubmitProceedingsService.call(cfe_connection, cfe_assessment_id, session_data)
+      SubmitEmploymentIncomeService.call(cfe_connection, cfe_assessment_id, session_data)
+      SubmitBenefitsService.call(cfe_connection, cfe_assessment_id, session_data)
+      SubmitIrregularIncomeService.call(cfe_connection, cfe_assessment_id, session_data)
+      SubmitVehicleService.call(cfe_connection, cfe_assessment_id, session_data)
+      SubmitAssetsService.call(cfe_connection, cfe_assessment_id, session_data)
+      SubmitRegularTransactionsService.call(cfe_connection, cfe_assessment_id, session_data)
+      SubmitApplicantService.call(cfe_connection, cfe_assessment_id, session_data)
+      SubmitPartnerService.call(cfe_connection, cfe_assessment_id, session_data)
+      result(cfe_connection, cfe_assessment_id, session_data)
     end
 
     def create_assessment_id(cfe_connection, session_data)
@@ -23,10 +23,10 @@ class CfeService
       cfe_connection.create_assessment_id(attributes)
     end
 
-    def result(cfe_connection, cfe_estimate_id, cfe_session_data)
-      cfe_connection.api_result(cfe_estimate_id).tap do |calculation_result|
+    def result(cfe_connection, cfe_assessment_id, session_data)
+      cfe_connection.api_result(cfe_assessment_id).tap do |calculation_result|
         calculation_result.level_of_help = if FeatureFlags.enabled?(:controlled)
-                                             cfe_session_data["level_of_help"]
+                                             session_data["level_of_help"]
                                            else
                                              "certificated"
                                            end

--- a/app/services/submit_applicant_service.rb
+++ b/app/services/submit_applicant_service.rb
@@ -1,6 +1,6 @@
 class SubmitApplicantService < BaseCfeService
-  def call(cfe_estimate_id, cfe_session_data)
-    estimate = ApplicantForm.from_session(cfe_session_data)
+  def call(cfe_assessment_id, session_data)
+    estimate = ApplicantForm.from_session(session_data)
 
     applicant = {
       date_of_birth: estimate.over_60 ? 70.years.ago.to_date : 50.years.ago.to_date,
@@ -9,6 +9,6 @@ class SubmitApplicantService < BaseCfeService
       employed: estimate.employed,
     }
 
-    cfe_connection.create_applicant(cfe_estimate_id, applicant)
+    cfe_connection.create_applicant(cfe_assessment_id, applicant)
   end
 end

--- a/app/services/submit_benefits_service.rb
+++ b/app/services/submit_benefits_service.rb
@@ -1,12 +1,12 @@
 class SubmitBenefitsService < BaseCfeService
-  def call(cfe_estimate_id, cfe_session_data)
-    benefits_form = BenefitsForm.from_session(cfe_session_data)
-    housing_benefit_form = HousingBenefitForm.from_session(cfe_session_data)
+  def call(cfe_assessment_id, session_data)
+    benefits_form = BenefitsForm.from_session(session_data)
+    housing_benefit_form = HousingBenefitForm.from_session(session_data)
     return if benefits_form.benefits.blank? && !housing_benefit_form.housing_benefit
 
-    housing_benefit_details_form = HousingBenefitDetailsForm.from_session(cfe_session_data) if housing_benefit_form.housing_benefit
+    housing_benefit_details_form = HousingBenefitDetailsForm.from_session(session_data) if housing_benefit_form.housing_benefit
     state_benefits = CfeParamBuilders::StateBenefits.call(benefits_form, housing_benefit_details_form)
 
-    cfe_connection.create_benefits(cfe_estimate_id, state_benefits)
+    cfe_connection.create_benefits(cfe_assessment_id, state_benefits)
   end
 end

--- a/app/services/submit_dependants_service.rb
+++ b/app/services/submit_dependants_service.rb
@@ -1,11 +1,11 @@
 class SubmitDependantsService < BaseCfeService
-  def call(cfe_estimate_id, cfe_session_data)
-    details_form = DependantDetailsForm.from_session(cfe_session_data)
+  def call(cfe_assessment_id, session_data)
+    details_form = DependantDetailsForm.from_session(session_data)
     children = CfeParamBuilders::Dependants.children(dependants: details_form.child_dependants,
                                                      count: details_form.child_dependants_count)
     adults = CfeParamBuilders::Dependants.adults(dependants: details_form.adult_dependants,
                                                  count: details_form.adult_dependants_count)
     dependants = children + adults
-    cfe_connection.create_dependants(cfe_estimate_id, dependants) if dependants.any?
+    cfe_connection.create_dependants(cfe_assessment_id, dependants) if dependants.any?
   end
 end

--- a/app/services/submit_employment_income_service.rb
+++ b/app/services/submit_employment_income_service.rb
@@ -1,11 +1,11 @@
 class SubmitEmploymentIncomeService < BaseCfeService
-  def call(cfe_estimate_id, cfe_session_data)
-    applicant_form = ApplicantForm.from_session(cfe_session_data)
+  def call(cfe_assessment_id, session_data)
+    applicant_form = ApplicantForm.from_session(session_data)
     return unless applicant_form.employed && !applicant_form.passporting
 
-    form = EmploymentForm.from_session(cfe_session_data)
+    form = EmploymentForm.from_session(session_data)
     employment_data = CfeParamBuilders::Employments.call(form)
 
-    cfe_connection.create_employment(cfe_estimate_id, employment_data)
+    cfe_connection.create_employment(cfe_assessment_id, employment_data)
   end
 end

--- a/app/services/submit_irregular_income_service.rb
+++ b/app/services/submit_irregular_income_service.rb
@@ -1,8 +1,8 @@
 class SubmitIrregularIncomeService < BaseCfeService
-  def call(cfe_estimate_id, cfe_session_data)
-    form = OtherIncomeForm.from_session(cfe_session_data)
+  def call(cfe_assessment_id, session_data)
+    form = OtherIncomeForm.from_session(session_data)
 
     payments = CfeParamBuilders::IrregularIncome.call(form)
-    cfe_connection.create_irregular_income(cfe_estimate_id, payments) if payments.any?
+    cfe_connection.create_irregular_income(cfe_assessment_id, payments) if payments.any?
   end
 end

--- a/app/services/submit_proceedings_service.rb
+++ b/app/services/submit_proceedings_service.rb
@@ -1,15 +1,15 @@
 class SubmitProceedingsService < BaseCfeService
-  def call(cfe_estimate_id, cfe_session_data)
-    applicant_form = ApplicantForm.from_session(cfe_session_data)
-    tribunal_form = TribunalForm.from_session(cfe_session_data)
+  def call(cfe_assessment_id, session_data)
+    applicant_form = ApplicantForm.from_session(session_data)
+    tribunal_form = TribunalForm.from_session(session_data)
     proceeding_type = if applicant_form.level_of_help == "certificated"
                         applicant_form.proceeding_type
                       elsif tribunal_form.upper_tribunal
-                        matter_type_form = MatterTypeForm.from_session(cfe_session_data)
+                        matter_type_form = MatterTypeForm.from_session(session_data)
                         matter_type_form.upper_tribunal_proceeding_type
                       else
                         ApplicantForm::PROCEEDING_TYPES[:other]
                       end
-    cfe_connection.create_proceeding_type(cfe_estimate_id, proceeding_type)
+    cfe_connection.create_proceeding_type(cfe_assessment_id, proceeding_type)
   end
 end

--- a/app/services/submit_regular_transactions_service.rb
+++ b/app/services/submit_regular_transactions_service.rb
@@ -1,9 +1,9 @@
 class SubmitRegularTransactionsService < BaseCfeService
-  def call(cfe_estimate_id, cfe_session_data)
-    outgoings_form = OutgoingsForm.from_session(cfe_session_data)
-    income_form = OtherIncomeForm.from_session(cfe_session_data)
+  def call(cfe_assessment_id, session_data)
+    outgoings_form = OutgoingsForm.from_session(session_data)
+    income_form = OtherIncomeForm.from_session(session_data)
 
     regular_transactions = CfeParamBuilders::RegularTransactions.call(income_form, outgoings_form)
-    cfe_connection.create_regular_payments(cfe_estimate_id, regular_transactions) if regular_transactions.any?
+    cfe_connection.create_regular_payments(cfe_assessment_id, regular_transactions) if regular_transactions.any?
   end
 end

--- a/app/services/submit_vehicle_service.rb
+++ b/app/services/submit_vehicle_service.rb
@@ -1,10 +1,10 @@
 class SubmitVehicleService < BaseCfeService
-  def call(cfe_estimate_id, cfe_session_data)
-    owned_model = VehicleForm.from_session(cfe_session_data)
+  def call(cfe_assessment_id, session_data)
+    owned_model = VehicleForm.from_session(session_data)
     return unless owned_model.vehicle_owned
 
-    details_model = ClientVehicleDetailsForm.from_session(cfe_session_data)
+    details_model = ClientVehicleDetailsForm.from_session(session_data)
     vehicles = CfeParamBuilders::Vehicles.call(details_model, in_dispute: details_model.vehicle_in_dispute)
-    cfe_connection.create_vehicle cfe_estimate_id, vehicles:
+    cfe_connection.create_vehicle cfe_assessment_id, vehicles:
   end
 end

--- a/app/views/estimates/_check_answer.html.slim
+++ b/app/views/estimates/_check_answer.html.slim
@@ -8,7 +8,7 @@
 
   dd.govuk-summary-list__actions
     - if link
-      = link_to(t("generic.change"), estimate_check_answer_path(@estimate_id, link), class: "govuk-link")
+      = link_to(t("generic.change"), estimate_check_answer_path(params[:id], link), class: "govuk-link")
     - elsif disputed_asset
       span.moj-badge.moj-badge--blue.moj-badge--large
         = t("generic.disputed_asset")

--- a/app/views/estimates/_check_answers_table.html.slim
+++ b/app/views/estimates/_check_answers_table.html.slim
@@ -7,7 +7,7 @@
       - if section.screen.present? && change_links
         p class="govuk-!-text-align-right"
           = link_to t("generic.change"),
-                    estimate_check_answer_path(@estimate_id, section.screen),
+                    estimate_check_answer_path(params[:id], section.screen),
                     class: "govuk-link govuk-!-font-size-19"
 
   - section.subsections.each do |subsection|
@@ -20,7 +20,7 @@
           - if subsection.screen.present? && change_links
             p class="govuk-!-text-align-right"
               = link_to t("generic.change"),
-                        estimate_check_answer_path(@estimate_id, subsection.screen),
+                        estimate_check_answer_path(params[:id], subsection.screen),
                         class: "govuk-link govuk-!-font-size-19"
 
     dl class="govuk-summary-list govuk-!-margin-bottom-9" id="field-list-#{subsection.label || section.label}"

--- a/app/views/estimates/_money_and_frequency_check_answer.slim
+++ b/app/views/estimates/_money_and_frequency_check_answer.slim
@@ -15,6 +15,6 @@
 
   dd.govuk-summary-list__actions
     - if link
-      = link_to(t("generic.change"), estimate_check_answer_path(@estimate_id, link), class: "govuk-link")
+      = link_to(t("generic.change"), estimate_check_answer_path(params[:id], link), class: "govuk-link")
     - elsif path
       = link_to(t("generic.change"), path, class: "govuk-link")

--- a/app/views/estimates/check_answers.html.slim
+++ b/app/views/estimates/check_answers.html.slim
@@ -11,7 +11,7 @@
   p = t(".submission_explanation")
 
   = form_with(url: estimates_path) do |form|
-    = hidden_field_tag :estimate_id, params.fetch(:id)
+    = hidden_field_tag :id, params.fetch(:id)
 
     = form.govuk_submit t(".call_to_action")
 

--- a/app/views/estimates/show.html.slim
+++ b/app/views/estimates/show.html.slim
@@ -51,5 +51,5 @@ h2.govuk-heading-m = t(".#{@model.level_of_help}_how_calculated")
 
 .govuk-button-group
   = link_to t(".start_another_check"), new_estimate_path, class: "govuk-button", data: { module: "govuk-button" }
-  = link_to t(".print_page"), print_estimate_path(params[:estimate_id]), target: "_blank", rel: "noopener", class: "govuk-button govuk-button--secondary"
-  = link_to t(".save_as_pdf"), download_estimate_path(params[:estimate_id]), target: "_blank", rel: "noopener", class: "govuk-button govuk-button--secondary"
+  = link_to t(".print_page"), print_estimate_path(params[:id]), target: "_blank", rel: "noopener", class: "govuk-button govuk-button--secondary"
+  = link_to t(".save_as_pdf"), download_estimate_path(params[:id]), target: "_blank", rel: "noopener", class: "govuk-button govuk-button--secondary"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
   resource :provider_users, only: %i[show create]
   resource :referrals, only: [:show]
 
-  resources :estimates, only: %i[new create] do
+  resources :estimates, only: %i[new create show] do
     resources :build_estimates, only: %i[show update]
     resources :check_answers, only: %i[show update]
     resources :benefits, except: %i[index show] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
   resource :provider_users, only: %i[show create]
   resource :referrals, only: [:show]
 
-  resources :estimates, only: %i[new create show] do
+  resources :estimates, only: %i[new create] do
     resources :build_estimates, only: %i[show update]
     resources :check_answers, only: %i[show update]
     resources :benefits, except: %i[index show] do


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-709)

## What changed and why

Separate estimate_id into concepts of assessment_code and assessment_id. This way we have one thing that appears in URLs (and therefore also appears in logs alongside user IP), and something else that is the key to all the user entered financial values stored in Redis. 

While I'm here, rename all other instances of `estimate_id` that aren't baked in by the framework, as neither CCQ nor CFE officially deals with estimates, they deal with checks and assessments.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
