### PR TITLE
Fix bug when controlled flag not enabled

### DIFF
--- a/app/services/submit_proceedings_service.rb
+++ b/app/services/submit_proceedings_service.rb
@@ -2,7 +2,7 @@ class SubmitProceedingsService < BaseCfeService
   def call(cfe_assessment_id, session_data)
     applicant_form = ApplicantForm.from_session(session_data)
     tribunal_form = TribunalForm.from_session(session_data)
-    proceeding_type = if applicant_form.level_of_help == "certificated"
+    proceeding_type = if applicant_form.level_of_help != "controlled"
                         applicant_form.proceeding_type
                       elsif tribunal_form.upper_tribunal
                         matter_type_form = MatterTypeForm.from_session(session_data)

--- a/spec/services/submit_proceedings_service_spec.rb
+++ b/spec/services/submit_proceedings_service_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.describe SubmitProceedingsService do
+  let(:service) { described_class }
+  let(:cfe_estimate_id) { SecureRandom.uuid }
+  let(:mock_connection) { instance_double(CfeConnection) }
+
+  describe ".call" do
+    context "when there is no controlled/certificated flag" do
+      let(:session_data) do
+        {
+          "proceeding_type" => "foo",
+        }
+      end
+
+      it "uses the specified proceeding type" do
+        expect(mock_connection).to receive(:create_proceeding_type).with(cfe_estimate_id, "foo")
+        service.call(mock_connection, cfe_estimate_id, session_data)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What changed and why

Since 10 feb, main has had a bug where domestic abuse proceeding types are ignored if the controlled feature flag is not enabled.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
