### PR TITLE
EL-754: CCQ deployments not running db migrations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -98,9 +98,5 @@ COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
 
 USER 1000
 
-# Ensure the database is set up and up to date
-CMD bundle exec rake db:create
-CMD bundle exec rake db:migrate
-
-CMD bundle exec rails server -b 0.0.0.0
+CMD ["docker/run"]
 

--- a/docker/run
+++ b/docker/run
@@ -2,5 +2,7 @@
 
 set -e
 
+./docker/wait_for_pg
+
 bundle exec rake db:migrate
 bundle exec rails server -b 0.0.0.0

--- a/docker/run
+++ b/docker/run
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -e
+
+bundle exec rake db:migrate
+bundle exec rails server -b 0.0.0.0

--- a/docker/wait_for_pg
+++ b/docker/wait_for_pg
@@ -1,0 +1,46 @@
+#!/bin/sh
+# Usage: wait_for_pg
+# expected ENV: POSTGRES_HOST, POSTGRES_PORT, POSTGRES_USER, POSTGRES_PASSWORD
+# Description:
+# Waits for postgres to be fully up and running
+
+export PGPASSWORD=${POSTGRES_PASSWORD-postgres}
+
+PROBE_TIMEOUT=${PROBE_TIMEOUT-15}
+POSTGRES_HOST=${POSTGRES_HOST-postgres}
+POSTGRES_PORT=${POSTGRES_PORT-5432}
+POSTGRES_USER=${POSTGRES_USER-postgres}
+
+log() {
+  echo "[wait-for] [`date +'%Y%m%d%H%M%S'`] $@"
+}
+
+wait_for() {
+  timeout=$1
+  log "wait '$POSTGRES_HOST':'$POSTGRES_PORT' up to '$timeout'"
+  for i in `seq $timeout` ; do
+    if probe; then
+      log "wait finish '$POSTGRES_HOST:$POSTGRES_PORT'"
+      exit 0
+    fi
+    log "wait attempt '${POSTGRES_HOST}:${POSTGRES_PORT}' [$i]"
+    sleep 1
+  done
+  log "[ERROR] wait timeout of '$timeout' on '$POSTGRES_HOST:$POSTGRES_PORT'"
+  exit 1
+}
+
+probe() {
+  echo "select 'ping';" | psql -h "$POSTGRES_HOST" -p "$POSTGRES_PORT" -U "$POSTGRES_USER" 2>/dev/null >/dev/null
+  return $?
+}
+
+if [ "$POSTGRES_USER" = "postgres" ]; then
+  log "This is a local or UAT deployment, so checking for postgres container"
+  wait_for "$PROBE_TIMEOUT"
+else
+  log "This is a staging or production deployment, no need to check for postgres container"
+  exit 0
+fi
+
+unset PGPASSWORD


### PR DESCRIPTION
The first issue was that we had multiple `CMD` statements in the Dockerfile, so the `migrate` one was being ignored. We also saw that Apply and CFE build in a conditional wait in case the UAT postgres pods aren't ready at first to accept migration commands. While we've not hit that issue yet, and at the risk of cargo culting a mystery shell script, it seemed sensible to have this precautionary measure in place.