### PR TITLE
[EL 776] Remove hint text from About their home and bullet from Level of help

### DIFF
--- a/app/views/estimate_flow/forms/_property_entry.html.slim
+++ b/app/views/estimate_flow/forms/_property_entry.html.slim
@@ -1,11 +1,9 @@
-- hint ||= nil
 = form_for(@form, url: wizard_path, method: :put) do |form|
 
   = form.govuk_error_summary t("generic.error_summary_title")
   = render "shared/heading",
            pre_header_text: t("estimate_flow.#{i18n_key}.caption"),
-           header_text: t("estimate_flow.#{i18n_key}.heading"),
-           post_header_text: hint
+           header_text: t("estimate_flow.#{i18n_key}.heading")
 
   = render "shared/money_input_with_hint",
            form:,

--- a/app/views/estimate_flow/property_entry.html.slim
+++ b/app/views/estimate_flow/property_entry.html.slim
@@ -8,7 +8,6 @@
           i18n_key: "property_entry",
           show_smod: true,
           show_joint_ownership: @estimate.partner.present?,
-          show_mortgage: @estimate.property_owned == "with_mortgage",
-          hint: t("estimate_flow.property_entry.second_caption_#{@estimate.level_of_help}")
+          show_mortgage: @estimate.property_owned == "with_mortgage"
 
 = render "property_sidebar", level_of_help: @estimate.level_of_help

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1045,8 +1045,6 @@ en:
       percentage_owned:
         input: What percentage of the home do they own?
         input_hint: Your client's name must be on the property deeds, lease, freehold or mortgage
-      second_caption_certificated: "If you make an application for civil legal aid, the property's value may be excluded from the financial assessment if your client has left their former matrimonial home because of domestic abuse"
-      second_caption_controlled: "When doing this check, the property's value can be excluded from the financial assessment if your client has left their former matrimonial home because of domestic abuse"
     partner_property_entry:
       heading: About the home the client lives in
       caption: The partner's finances

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -509,7 +509,6 @@ en:
         - legal help
         - help at court
         - help with family mediation
-        - civil certificated or licensed legal work
         - family mediation
         - family help (lower)
       also_includes: "It also includes legal representation for proceedings in:"


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-776)

## What changed and why

We need to remove some hint text from the 'About their home' section for controlled and certificated flows. We also need to remove one of the bullets from the 'Level of help' page.

This PR removes the hint text and the bullet.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
