### PR TITLE
EL-783: Add database health check

### DIFF
--- a/app/services/health_check_service.rb
+++ b/app/services/health_check_service.rb
@@ -1,7 +1,13 @@
 class HealthCheckService
   def self.call
-    short_term_persistence_healthy? && cfe_healthy?
+    database_healthy? && short_term_persistence_healthy? && cfe_healthy?
   rescue StandardError
+    false
+  end
+
+  def self.database_healthy?
+    ActiveRecord::Base.connection.active? && AnalyticsEvent.count.is_a?(Numeric)
+  rescue PG::ConnectionBad, PG::UndefinedTable
     false
   end
 

--- a/spec/requests/statuses_controller_spec.rb
+++ b/spec/requests/statuses_controller_spec.rb
@@ -20,6 +20,12 @@ RSpec.describe "status requests" do
       expect(response_json).to eq("healthy" => true)
     end
 
+    it "returns false if there is a problem reading from the database" do
+      allow(AnalyticsEvent).to receive(:count).and_raise(PG::UndefinedTable)
+      get("/health-including-dependents")
+      expect(response).not_to be_successful
+    end
+
     it "returns false if there is a problem writing to the cache" do
       allow(Rails.cache).to receive(:write).and_return(false)
       get("/health-including-dependents")


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-783)

## What changed and why

Add a check to see if the database is healthy. This is important n UAT environments because if the DB pod has been cycled (and so hasn't had migrations applied), this will cause the web server pod to cycle, in turn ensuring migrations to run on the DB pod.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
