### PR TITLE
[EL-803] Add disputed_non_property_disregard into capitals

### DIFF
--- a/app/models/calculation_result.rb
+++ b/app/models/calculation_result.rb
@@ -155,7 +155,7 @@ class CalculationResult
   def client_capital_subtotal_rows
     rows = {
       total_capital: monetise(api_response.dig(:result_summary, :capital, :total_capital)),
-      smod_disregard: monetise(-api_response.dig(:result_summary, :capital, :subject_matter_of_dispute_disregard)),
+      smod_non_property_disregard: monetise(-api_response.dig(:result_summary, :capital, :disputed_non_property_disregard)),
       pensioner_capital_disregard: monetise(-api_response.dig(:result_summary, :capital, :pensioner_disregard_applied)),
     }
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1503,7 +1503,7 @@ en:
           text: Pensioner disregard
           hint: Applied to total capital up to a maximum of £100,000
           alt_hint: Applied to remaining capital after disputed asset disregard has been applied, and up to a maximum of £100,000
-        smod_disregard:
+        smod_non_property_disregard:
           text: Disputed asset disregard
           hint: Equal to the assessed value of all assets marked as disputed and capped at £100,000
           alt_hint: Equal to the assessed value of all assets marked as disputed and capped at £100,000

--- a/spec/factories/api_results.rb
+++ b/spec/factories/api_results.rb
@@ -38,6 +38,7 @@ FactoryBot.define do
               "result": "eligible" },
           ],
           total_capital: 0,
+          disputed_non_property_disregard: 0,
         },
       }
     end

--- a/spec/views/results_page/client_financial_content_spec.rb
+++ b/spec/views/results_page/client_financial_content_spec.rb
@@ -37,7 +37,8 @@ RSpec.describe "estimates/show.html.slim" do
           capital: {
             pensioner_disregard_applied: 3_000,
             pensioner_capital_disregard: 100_000,
-            subject_matter_of_dispute_disregard: 1_000,
+            disputed_non_property_disregard: 1_000,
+            subject_matter_of_dispute_disregard: 2_000,
             total_capital: 12_000,
             total_property: 0.0,
             total_vehicle: 3_000,

--- a/spec/views/results_page/partner_financial_content_spec.rb
+++ b/spec/views/results_page/partner_financial_content_spec.rb
@@ -49,6 +49,7 @@ RSpec.describe "estimates/show.html.slim" do
           capital: {
             pensioner_capital_disregard: 0,
             subject_matter_of_dispute_disregard: 0,
+            disputed_non_property_disregard: 0,
             pensioner_disregard_applied: 0,
             proceeding_types: [
               { "ccms_code": "SE013",


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-803)

## What changed and why

In capital assets (additional home, vehicle, jewellery, savings etc) we were using the `subject_matter_of_dispute_disregard` value. This value includes the disregard for disputed main property and therefore did not look accurate on the results page. We are now using a new field, `disputed_non_property_disregard` which is a total of disregarded assets not including the main property.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
