### PR TITLE
EL-793: Use a specific analytics event to track level of help

### DIFF
--- a/app/controllers/build_estimates_controller.rb
+++ b/app/controllers/build_estimates_controller.rb
@@ -3,6 +3,7 @@ class BuildEstimatesController < EstimateFlowController
     @form = Flow::Handler.model_from_params(step, params, session_data)
 
     if @form.valid?
+      track_choices(@form)
       session_data.merge!(@form.session_attributes)
       estimate = load_estimate
 

--- a/app/controllers/check_answers_controller.rb
+++ b/app/controllers/check_answers_controller.rb
@@ -5,6 +5,7 @@ class CheckAnswersController < EstimateFlowController
     @form = Flow::Handler.model_from_params(step, params, session_data)
 
     if @form.valid?
+      track_choices(@form)
       session_data.merge!(@form.session_attributes)
       estimate = load_estimate
       if StepsHelper.last_step_in_group?(estimate, step)

--- a/app/controllers/estimate_flow_controller.rb
+++ b/app/controllers/estimate_flow_controller.rb
@@ -30,4 +30,8 @@ protected
   def page_name
     step
   end
+
+  def track_choices(form)
+    ChoiceAnalyticsService.call(form, assessment_code, cookies[BROWSER_ID_COOKIE])
+  end
 end

--- a/app/services/choice_analytics_service.rb
+++ b/app/services/choice_analytics_service.rb
@@ -1,0 +1,27 @@
+class ChoiceAnalyticsService
+  def self.call(form, assessment_code, browser_id)
+    # For the most part, our analytics data should _only_ contain information
+    # about the pages viewed by users, not the content of any forms they make.
+
+    # This is because analytics events are keyed by the assessment_code, which
+    # is in the URL so also in the application logs, so is stored alongside the
+    # user's IP address. We don't in general want to store any more information
+    # in our analytics data than is also available in the application logs.
+
+    # There are rare and specific exceptions around choices that users make
+    # that are (a) important to build meaningful metrics from our analytics data
+    # and (b) not information that is in any way sensitive. This service
+    # exists to create analytics data from those rare and specific choices
+    case form
+    when LevelOfHelpForm
+      AnalyticsEvent.create!(
+        event_type: "#{form.level_of_help}_level_of_help_chosen",
+        page: :level_of_help_choice,
+        assessment_code:,
+        browser_id:,
+      )
+    end
+  rescue StandardError => e
+    ErrorService.call(e)
+  end
+end

--- a/app/services/metrics_service.rb
+++ b/app/services/metrics_service.rb
@@ -89,14 +89,13 @@ private
   def percent_controlled
     return if assessments_completed.zero?
 
-    # ASSUMPTION: All and only certificated assessments will involve viewing the `vehicle` page prior to reaching the result screen
-    certificated_completed = relevant_events.joins("LEFT JOIN analytics_events ae2 ON ae2.assessment_code = analytics_events.assessment_code")
-                                            .where(event_type: "page_view", page: "view_results")
-                                            .where(ae2: { event_type: "page_view", page: "vehicle" })
-                                            .distinct
-                                            .count(:assessment_code)
+    controlled_completed = relevant_events.joins("LEFT JOIN analytics_events ae2 ON ae2.assessment_code = analytics_events.assessment_code")
+                                          .where(event_type: "page_view", page: "view_results")
+                                          .where(ae2: { event_type: "controlled_level_of_help_chosen", page: "level_of_help_choice" })
+                                          .distinct
+                                          .count(:assessment_code)
 
-    100 - (100 * certificated_completed / assessments_completed.to_f).round
+    (100 * controlled_completed / assessments_completed.to_f).round
   end
 
   def top_validation_screens

--- a/spec/forms/level_of_help_form_spec.rb
+++ b/spec/forms/level_of_help_form_spec.rb
@@ -2,9 +2,10 @@ require "rails_helper"
 
 RSpec.describe "level_of_help", type: :feature do
   let(:level_of_help_header) { I18n.t("estimate_flow.level_of_help.title") }
+  let(:assessment_code) { "assessment-code" }
 
   before do
-    visit "estimates/foo/build_estimates/level_of_help"
+    visit "estimates/#{assessment_code}/build_estimates/level_of_help"
   end
 
   it "shows an error message if no value is entered" do
@@ -17,5 +18,11 @@ RSpec.describe "level_of_help", type: :feature do
     choose "Civil certificated or licensed legal work"
     click_on "Save and continue"
     expect(session_contents["level_of_help"]).to eq "certificated"
+  end
+
+  it "stores the choice as an analytics event" do
+    choose "Civil certificated or licensed legal work"
+    click_on "Save and continue"
+    expect(AnalyticsEvent.find_by(assessment_code:, page: "level_of_help_choice").event_type).to eq "certificated_level_of_help_chosen"
   end
 end

--- a/spec/services/choice_analytics_service_spec.rb
+++ b/spec/services/choice_analytics_service_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+RSpec.describe ChoiceAnalyticsService do
+  describe ".call" do
+    let(:form) { LevelOfHelpForm.new }
+
+    it "handles errors without crashing" do
+      expect(ErrorService).to receive(:call)
+      allow(AnalyticsEvent).to receive(:create!).and_raise "Error!"
+      expect { described_class.call(form, "assessment_code", nil) }.not_to raise_error
+    end
+  end
+end

--- a/spec/services/metrics_service_spec.rb
+++ b/spec/services/metrics_service_spec.rb
@@ -75,10 +75,12 @@ RSpec.describe MetricsService do
           # Completed controlled assessment by user 2
           create :analytics_event, assessment_code: "CODE4", page: "applicant", browser_id: "BROWSER2", created_at: 1.day.ago
           create :analytics_event, assessment_code: "CODE4", page: "view_results", browser_id: "BROWSER2", created_at: 1.day.ago
+          create :analytics_event, assessment_code: "CODE4", event_type: "controlled_level_of_help_chosen", page: "level_of_help_choice", browser_id: "BROWSER2", created_at: 1.day.ago
 
           # Completed controlled assessment
           create :analytics_event, assessment_code: "CODE5", page: "applicant", created_at: 1.day.ago
           create :analytics_event, assessment_code: "CODE5", page: "view_results", created_at: 1.day.ago
+          create :analytics_event, assessment_code: "CODE5", event_type: "controlled_level_of_help_chosen", page: "level_of_help_choice", created_at: 1.day.ago
 
           create :analytics_event, page: "index_start"
         end


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-793)

## What changed and why

Use the contents of a form to generate an analytics event and use that event in our metrics. And make it very clear why we should only do that very rarely.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
