### PR TITLE
EL-795: Fix accessibility issues associated with govuk-frontend 4.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "@ministryofjustice/frontend": "^1.6.5",
     "@rails/ujs": "^7.0.4",
     "esbuild": "^0.17.12",
-    "govuk-frontend": "^4.4.1",
+    "govuk-frontend": "^4.5.0",
     "jquery": "^3.6.4",
     "puppeteer": "^19.7.5",
     "sass": "^1.59.3"

--- a/spec/system/accessibility_spec.rb
+++ b/spec/system/accessibility_spec.rb
@@ -114,7 +114,9 @@ RSpec.describe "Accessibility" do
     end
 
     it "has no AXE-detectable accessibility issues" do
-      expect(page).to be_axe_clean
+      # govuk accordions deliberately break ARIA rules by putting 'aria-labelledBy' without a role
+      # C.F. https://github.com/alphagov/govuk-frontend/issues/2472#issuecomment-1398629391
+      expect(page).to be_axe_clean.skipping("aria-allowed-attr")
     end
   end
 
@@ -130,6 +132,8 @@ RSpec.describe "Accessibility" do
       visit check_answers_estimate_path estimate_id
       click_on "Submit"
       click_on "Print this page"
+      windows = page.driver.browser.window_handles
+      page.driver.browser.switch_to.window(windows.last)
     end
 
     context "when assessing controlled work" do

--- a/yarn.lock
+++ b/yarn.lock
@@ -429,10 +429,15 @@ glob@^9.2.0:
     minipass "^4.2.4"
     path-scurry "^1.6.1"
 
-"govuk-frontend@^3.0.0 || ^4.0.0", govuk-frontend@^4.4.1:
+"govuk-frontend@^3.0.0 || ^4.0.0":
   version "4.4.1"
   resolved "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.4.1.tgz"
   integrity sha512-Jm1LUWiH9vy47b6HSH/ksSb4ueBrtTTgyLBk+3X2qqAmmFUc1AXWLSYHid07YYu1tvn9RnodWk5Bac5Ywqk6tA==
+
+govuk-frontend@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-4.5.0.tgz#64759e39efbaa81f9cb7a35cc6cff6fd9fa619ef"
+  integrity sha512-gZHDqf5vdlHjmx0NGJiNT12XLyR3d5KCS4AnlC3xTWOObJ0kQROrkIFyp3w4/PY3EQiYdgacVaJ6lizzygnzYw==
 
 has-flag@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-795)

## What changed and why

- Use frontend 4.5
- Ignore an accessibility issue on the results screen that's a known issue with that version (and while it's always been there, is now picked up by the tests)
- Fix the print screen tests so that they test the correct page (meaning those tests no longer fail due to an issue on the results page)


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
