### PR TITLE
EL-791: Add a query to surface the last page reached for incomplete checks

### DIFF
--- a/app/services/metrics_service.rb
+++ b/app/services/metrics_service.rb
@@ -13,6 +13,10 @@ class MetricsService
     validation_dataset = client.datasets.find_or_create(ENV.fetch("GECKOBOARD_VALIDATION_DATASET_NAME", "validations"),
                                                         **validation_dataset_definition)
     validation_dataset.put(validations)
+
+    last_page_dataset = client.datasets.find_or_create(ENV.fetch("GECKOBOARD_LAST_PAGE_DATASET_NAME", "last_pages"),
+                                                       **last_page_dataset_definition)
+    last_page_dataset.put(last_pages)
   end
 
 private
@@ -63,6 +67,25 @@ private
     end
   end
 
+  def last_page_dataset_definition
+    {
+      fields: [
+        Geckoboard::NumberField.new(:checks, name: "Checks"),
+        Geckoboard::StringField.new(:screen, name: "Last screen viewed"),
+        Geckoboard::StringField.new(:context, name: "Context of the numbers applied"),
+      ],
+    }
+  end
+
+  def last_pages
+    [
+      exit_pages(:controlled, :all_time),
+      exit_pages(:certificated, :all_time),
+      exit_pages(:controlled, :current_month),
+      exit_pages(:certificated, :current_month),
+    ].flatten
+  end
+
   def assessments_started
     @assessments_started ||= relevant_events.where.not(assessment_code: nil).count("DISTINCT assessment_code")
   end
@@ -109,5 +132,55 @@ private
   def relevant_events
     period_end = Date.current.beginning_of_day
     AnalyticsEvent.where(created_at: (period_end - DAYS_TO_CONSIDER.days)..period_end)
+  end
+
+  def exit_pages(level_of_help, period)
+    query_exit_pages(level_of_help, period).map do |result|
+      {
+        checks: result["checks"],
+        page: result["page"],
+        context: "#{level_of_help}_#{period}",
+      }
+    end
+  end
+
+  QUERY = "
+  SELECT   last_pages.page AS page, COUNT(last_pages.page) AS checks
+  FROM     (
+              SELECT    last_page_events.page
+              FROM      analytics_events last_page_events
+              LEFT JOIN analytics_events level_of_help_filter
+              ON        level_of_help_filter.assessment_code = last_page_events.assessment_code
+              LEFT JOIN analytics_events incomplete_check_filter
+              ON        incomplete_check_filter.assessment_code = last_page_events.assessment_code
+              AND       incomplete_check_filter.event_type = 'page_view'
+              AND       incomplete_check_filter.page = 'view_results'
+              LEFT JOIN analytics_events time_filter
+              ON        time_filter.assessment_code = last_page_events.assessment_code
+              WHERE     last_page_events.event_type = 'page_view'
+              AND       last_page_events.created_at = (
+                          SELECT MAX(created_at)
+                          FROM   analytics_events journey
+                          WHERE  journey.event_type = 'page_view'
+                          AND    last_page_events.assessment_code = journey.assessment_code
+                        )
+              AND       level_of_help_filter.page = 'level_of_help_choice'
+              AND       level_of_help_filter.event_type = :choice
+              AND       incomplete_check_filter.id IS NULL
+              AND       time_filter.created_at BETWEEN :range_start AND :range_end
+              GROUP BY  last_page_events.assessment_code, last_page_events.page
+           ) last_pages
+  GROUP BY last_pages.page
+  ORDER BY COUNT(last_pages.page) DESC
+  LIMIT    10
+  ".freeze
+
+  def query_exit_pages(level_of_help, period)
+    choice = "#{level_of_help}_level_of_help_chosen"
+    range_start = period == :current_month ? Date.current.beginning_of_month : 100.years.ago
+    range_end = Time.current
+    ActiveRecord::Base.connection.execute(
+      ApplicationRecord.sanitize_sql([QUERY, { choice:, range_start:, range_end: }]),
+    )
   end
 end

--- a/app/services/metrics_service.rb
+++ b/app/services/metrics_service.rb
@@ -138,7 +138,7 @@ private
     query_exit_pages(level_of_help, period).map do |result|
       {
         checks: result["checks"],
-        page: result["page"],
+        screen: result["page"],
         context: "#{level_of_help}_#{period}",
       }
     end

--- a/helm_deploy/laa-estimate-eligibility/templates/_envs.tpl
+++ b/helm_deploy/laa-estimate-eligibility/templates/_envs.tpl
@@ -88,6 +88,8 @@ env:
     value:  {{ .Values.geckoboard.metricsDataset }}
   - name: GECKOBOARD_VALIDATION_DATASET_NAME
     value:  {{ .Values.geckoboard.validationsDataset }}
+  - name: GECKOBOARD_LAST_PAGE_DATASET_NAME
+    value:  {{ .Values.geckoboard.lastPagesDataset }}
   - name: GECKOBOARD_ENABLED
     value: {{ .Values.geckoboard.enabled }}
 

--- a/helm_deploy/laa-estimate-eligibility/values/production.yaml
+++ b/helm_deploy/laa-estimate-eligibility/values/production.yaml
@@ -60,4 +60,5 @@ featureFlags:
 geckoboard:
   metricsDataset: "ccq_metrics_production"
   validationsDataset: "ccq_validations_production"
+  lastPagesDataset: "ccq_last_pages_production"
   enabled: enabled

--- a/helm_deploy/laa-estimate-eligibility/values/staging.yaml
+++ b/helm_deploy/laa-estimate-eligibility/values/staging.yaml
@@ -60,4 +60,5 @@ featureFlags:
 geckoboard:
   metricsDataset: "ccq_metrics_staging"
   validationsDataset: "ccq_validations_staging"
+  lastPagesDataset: "ccq_last_pages_staging"
   enabled: enabled

--- a/helm_deploy/laa-estimate-eligibility/values/uat.yaml
+++ b/helm_deploy/laa-estimate-eligibility/values/uat.yaml
@@ -78,4 +78,5 @@ postgresql:
 geckoboard:
   metricsDataset: "ccq_metrics_uat"
   validationsDataset: "ccq_validations_uat"
+  lastPagesDataset: "ccq_last_pages_uat"
   enabled: not_enabled

--- a/spec/services/metrics_service_spec.rb
+++ b/spec/services/metrics_service_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe MetricsService do
     let(:dataset_client) { instance_double(Geckoboard::DatasetsClient) }
     let(:metric_dataset) { instance_double(Geckoboard::Dataset) }
     let(:validation_dataset) { instance_double(Geckoboard::Dataset) }
+    let(:last_page_dataset) { instance_double(Geckoboard::Dataset) }
 
     context "when api key is not set" do
       it "does nothing" do
@@ -29,6 +30,8 @@ RSpec.describe MetricsService do
             metric_dataset
           when "validations"
             validation_dataset
+          when "last_pages"
+            last_page_dataset
           end
         end
       end
@@ -48,6 +51,7 @@ RSpec.describe MetricsService do
             ],
           )
           expect(validation_dataset).to receive(:put).with([])
+          expect(last_page_dataset).to receive(:put).with([])
           described_class.call
         end
       end
@@ -68,6 +72,7 @@ RSpec.describe MetricsService do
           create :analytics_event, assessment_code: "CODE2", page: "view_results", browser_id: "BROWSER1", created_at: 1.day.ago
 
           # Incomplete certificated assessment by user 1
+          create :analytics_event, assessment_code: "CODE3", event_type: "controlled_level_of_help_chosen", page: "level_of_help_choice", browser_id: "BROWSER1", created_at: 1.day.ago
           create :analytics_event, assessment_code: "CODE3", page: "applicant", browser_id: "BROWSER1", created_at: 1.day.ago
           create :analytics_event, assessment_code: "CODE3", page: "outgoings", browser_id: "BROWSER1", created_at: 1.day.ago, event_type: "validation_message"
           create :analytics_event, assessment_code: "CODE3", page: "vehicle", browser_id: "BROWSER1", created_at: 1.day.ago
@@ -110,6 +115,12 @@ RSpec.describe MetricsService do
                 date: 1.day.ago.to_date,
                 screen: "outgoings",
               },
+            ],
+          )
+          expect(last_page_dataset).to receive(:put).with(
+            [
+              { checks: 1, context: "controlled_all_time", page: "vehicle" },
+              { checks: 1, context: "controlled_current_month", page: "vehicle" },
             ],
           )
           described_class.call

--- a/spec/services/metrics_service_spec.rb
+++ b/spec/services/metrics_service_spec.rb
@@ -119,8 +119,8 @@ RSpec.describe MetricsService do
           )
           expect(last_page_dataset).to receive(:put).with(
             [
-              { checks: 1, context: "controlled_all_time", page: "vehicle" },
-              { checks: 1, context: "controlled_current_month", page: "vehicle" },
+              { checks: 1, context: "controlled_all_time", screen: "vehicle" },
+              { checks: 1, context: "controlled_current_month", screen: "vehicle" },
             ],
           )
           described_class.call


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-791)

## What changed and why

Create a new dataset that contains the most common pages on which incomplete checks are abandoned, for both the current month and all time, divided by controlled vs certificated

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
