### PR TITLE
EL-818: Extra ineligibility line on results page

### DIFF
--- a/app/models/calculation_result.rb
+++ b/app/models/calculation_result.rb
@@ -27,6 +27,10 @@ class CalculationResult
     api_response.dig(:result_summary, section, :proceeding_types).none? { _1[:result] == "pending" }
   end
 
+  def ineligible?(section)
+    api_response.dig(:result_summary, section, :proceeding_types).all? { _1[:result] == "ineligible" }
+  end
+
   def capital_contribution
     monetise(api_response.dig(:result_summary, :overall_result, :capital_contribution))
   end

--- a/app/views/estimates/_capital_table.html.slim
+++ b/app/views/estimates/_capital_table.html.slim
@@ -85,3 +85,5 @@
     - body.row(classes: %w[solid-bottom-border]) do |row|
       - row.cell(text: t("estimates.show.capital_upper_threshold"))
       - row.cell(text: @model.capital_upper_threshold, numeric: true)
+
+= render "ineligible_explanation", value_type: :capital

--- a/app/views/estimates/_income_table.html.slim
+++ b/app/views/estimates/_income_table.html.slim
@@ -22,3 +22,5 @@ p.govuk-body = t("estimates.show.period_conversion_hint")
     - body.row(classes: %w[solid-bottom-border]) do |row|
       - row.cell(text: t("estimates.show.gross_income_upper_threshold"))
       - row.cell(text: @model.gross_income_upper_threshold, numeric: true)
+
+= render "ineligible_explanation", value_type: :gross_income

--- a/app/views/estimates/_ineligible_explanation.html.slim
+++ b/app/views/estimates/_ineligible_explanation.html.slim
@@ -1,0 +1,8 @@
+- if @model.ineligible?(value_type)
+  - subject = t("estimates.show.ineligible_explanation.#{@model.has_partner? ? 'subject_with_partner' : 'subject_no_partner'}")
+  - outcome = t("estimates.show.ineligible_explanation.#{@model.has_partner? ? 'outcome_with_partner' : 'outcome_no_partner'}")
+  p.govuk-body class="govuk-!-margin-top-8"
+    = t("estimates.show.ineligible_explanation.text",
+        subject:,
+        outcome:,
+        value_type: t("estimates.show.ineligible_explanation.#{value_type}"))

--- a/app/views/estimates/_outgoings_table.html.slim
+++ b/app/views/estimates/_outgoings_table.html.slim
@@ -29,3 +29,5 @@ p.govuk-body = t("estimates.show.period_conversion_hint")
     - body.row(classes: %w[solid-bottom-border]) do |row|
       - row.cell(text: t("estimates.show.disposable_income_upper_threshold"))
       - row.cell(text: @model.disposable_income_upper_threshold, numeric: true)
+
+= render "ineligible_explanation", value_type: :disposable_income

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1603,6 +1603,15 @@ en:
           - Keep the form, with any evidence provided by your client, for your records.
         manual_header:  Complete a controlled work form yourself
         manual_instruction: Download a <a href='https://www.gov.uk/government/collections/controlled-work-application-forms' target='_blank' rel='noreferrer noopener'>controlled work application form</a>. Some of these can be filled in on a computer.
+      ineligible_explanation:
+        text: Your %{subject} %{value_type} exceeds the upper limit. This means %{outcome} not qualify for legal aid.
+        subject_no_partner: client’s
+        subject_with_partner: client and their partner’s combined
+        gross_income: total monthly income
+        outcome_no_partner: they do
+        outcome_with_partner: your client does
+        disposable_income: disposable monthly income
+        capital: disposable capital
     limits_table:
       calculation_information: We’ve used the information you provided to compare your client’s income and outgoings. This allows us to calculate their monthly disposable income.
       regulations_html: "All the regulations referred to on this page can be found in the <a href='http://www.legislation.gov.uk/all?title=Civil%20Legal%20Aid%20%28Financial%20Resources%20'>Civil Legal Aid (Financial Resources and Payment for Services) Regulations 2013 and subsequent amendments</a>."

--- a/spec/views/results_page/eligibility_content_spec.rb
+++ b/spec/views/results_page/eligibility_content_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "estimates/show.html.slim" do
       let(:api_response) { FactoryBot.build(:api_result, eligible: "eligible") }
 
       it "show eligible" do
-        expect(rendered).to include "Your client is likely to qualify for civil legal aid"
+        expect(page_text).to include "Your client is likely to qualify for civil legal aid"
       end
     end
 
@@ -33,7 +33,7 @@ RSpec.describe "estimates/show.html.slim" do
       let(:api_response) { FactoryBot.build(:api_result, eligible: "eligible") }
 
       it "shows eligibility message" do
-        expect(rendered).to include "Your client is likely to qualify for civil legal aid, for controlled work and family mediation"
+        expect(page_text).to include "Your client is likely to qualify for civil legal aid, for controlled work and family mediation"
       end
     end
 
@@ -42,16 +42,48 @@ RSpec.describe "estimates/show.html.slim" do
       let(:api_response) { FactoryBot.build(:api_result, eligible: "contribution_required") }
 
       it "show eligible" do
-        expect(rendered).to include "Your client is likely to qualify for civil legal aid"
+        expect(page_text).to include "Your client is likely to qualify for civil legal aid"
       end
     end
 
     context "when not eligible" do
       let(:level_of_help) { "certificated" }
-      let(:api_response) { FactoryBot.build(:api_result, eligible: "ineligible") }
+      let(:api_response) do
+        FactoryBot.build(
+          :api_result,
+          eligible: "ineligible",
+          result_summary: {
+            overall_result: {
+              result: "ineligible",
+            },
+            gross_income: {
+              proceeding_types: [
+                { "ccms_code": "SE013",
+                  "client_involvement_type": "I",
+                  "upper_threshold": 2657.0,
+                  "lower_threshold": 0.0,
+                  "result": "ineligible" },
+              ],
+            },
+            disposable_income: {
+              proceeding_types: [
+                { "result": "pending" },
+              ],
+            },
+            capital: {
+              proceeding_types: [
+                { "result": "pending" },
+              ],
+            },
+          },
+        )
+      end
 
       it "show ineligible" do
-        expect(rendered).to include("Your client is not likely to qualify for civil legal aid")
+        expect(page_text).to include(
+          "Your client’s total monthly income exceeds the upper limit. This means they do not qualify for legal aid.",
+        )
+        expect(page_text).to include("Your client is not likely to qualify for civil legal aid")
       end
     end
   end


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-818)

## What changed and why

Add missing ineligibility explanation at bottom of tables on results page

## Guidance to review

The CFE response shows whether each section (gross income, disposable income, capital) is ineligible by associating an "ineligible" result string with one or more of the proceeding types that are attached to that section. But in CCQ there is only ever one proceeding type, because we only ever feed CFE one proceeding type for a check.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
