### PR TITLE
EL-811: Hide domestic abuse guidance where not relevant

### DIFF
--- a/app/helpers/applicant_helper.rb
+++ b/app/helpers/applicant_helper.rb
@@ -4,12 +4,12 @@ module ApplicantHelper
       t("estimate_flow.applicant.passporting_guidance.text") => t("estimate_flow.applicant.passporting_guidance.#{level_of_help}.link"),
       t("estimate_flow.applicant.pensioner_guidance.text") => t("estimate_flow.applicant.pensioner_guidance.#{level_of_help}.link"),
     }
-    if FeatureFlags.enabled?(:asylum_and_immigration) && level_of_help != "controlled"
-      links
-    else
+    if !FeatureFlags.enabled?(:asylum_and_immigration) && level_of_help != "controlled"
       links.merge({
         t("estimate_flow.applicant.domestic_abuse_guidance.text") => t("estimate_flow.applicant.domestic_abuse_guidance.link"),
       })
+    else
+      links
     end
   end
 end

--- a/spec/forms/applicant_form_spec.rb
+++ b/spec/forms/applicant_form_spec.rb
@@ -39,6 +39,10 @@ RSpec.describe "applicant", type: :feature do
     expect(page).to have_content "Is your client likely to be the applicant in a domestic abuse matter?"
   end
 
+  it "shows domestic abuse guidance" do
+    expect(page).to have_content "Guidance on domestic abuse or violence"
+  end
+
   context "when level of help is explicitly set to 'controlled'" do
     before do
       set_session(assessment_code, { "level_of_help" => "controlled" })
@@ -48,11 +52,19 @@ RSpec.describe "applicant", type: :feature do
     it "hides domestic abuse question" do
       expect(page).not_to have_content "Is your client likely to be the applicant in a domestic abuse matter?"
     end
+
+    it "hides domestic abuse guidance" do
+      expect(page).not_to have_content "Guidance on domestic abuse or violence"
+    end
   end
 
   context "when asylum and immigration feature flag is enabled", :asylum_and_immigration_flag do
     it "hides domestic abuse question" do
       expect(page).not_to have_content "Is your client likely to be the applicant in a domestic abuse matter?"
+    end
+
+    it "hides domestic abuse guidance" do
+      expect(page).not_to have_content "Guidance on domestic abuse or violence"
     end
   end
 end


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-811)

## What changed and why

Only show domestic abuse guidance where it is relevant.

## Guidance to review

For certificated work, domestic abuse cases have different rules applied, but for controlled they don't. So we only show an 'is this domestic abuse' case for certificated work. Furthermore, when we release asylum and immigration we'll stop asking the domestic abuse question on the applicant screen and will instead ask it on the matter type screen.

So we only want to show the domestic abuse guidance if it's _not_ controlled work and the A&I feature flag is _not_ enabled.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
