### PR TITLE
EL-826 Removed trailing whitespace: outstanding_mortgage field

### DIFF
--- a/app/services/cfe/submit_assets_service.rb
+++ b/app/services/cfe/submit_assets_service.rb
@@ -16,7 +16,7 @@ module Cfe
       if asset_form.property_value.positive?
         second_property = {
           value: asset_form.property_value,
-          outstanding_mortgage: asset_form.property_mortgage.strip,
+          outstanding_mortgage: asset_form.property_mortgage.to_s.strip.to_f,
           percentage_owned: asset_form.property_percentage_owned,
           subject_matter_of_dispute: (asset_form.property_in_dispute? && smod_applicable?) || false,
         }
@@ -32,7 +32,7 @@ module Cfe
                            end
         main_home = {
           value: property_entry_form.house_value,
-          outstanding_mortgage: (property_entry_form.mortgage.strip if property_form.owned_with_mortgage?) || 0,
+          outstanding_mortgage: (property_entry_form.mortgage.to_s.strip.to_f if property_form.owned_with_mortgage?) || 0,
           percentage_owned:,
           subject_matter_of_dispute: (property_entry_form.house_in_dispute && smod_applicable?) || false,
         }
@@ -41,7 +41,7 @@ module Cfe
         partner_property_entry_form = PartnerPropertyEntryForm.from_session(@session_data)
         main_home = {
           value: partner_property_entry_form.house_value,
-          outstanding_mortgage: (partner_property_entry_form.mortgage.strip if partner_property_form.owned_with_mortgage?) || 0,
+          outstanding_mortgage: (partner_property_entry_form.mortgage.to_s.strip.to_f if partner_property_form.owned_with_mortgage?) || 0,
           percentage_owned: partner_property_entry_form.percentage_owned,
           subject_matter_of_dispute: false,
         }

--- a/app/services/cfe/submit_assets_service.rb
+++ b/app/services/cfe/submit_assets_service.rb
@@ -16,7 +16,7 @@ module Cfe
       if asset_form.property_value.positive?
         second_property = {
           value: asset_form.property_value,
-          outstanding_mortgage: asset_form.property_mortgage,
+          outstanding_mortgage: asset_form.property_mortgage.strip,
           percentage_owned: asset_form.property_percentage_owned,
           subject_matter_of_dispute: (asset_form.property_in_dispute? && smod_applicable?) || false,
         }
@@ -32,7 +32,7 @@ module Cfe
                            end
         main_home = {
           value: property_entry_form.house_value,
-          outstanding_mortgage: (property_entry_form.mortgage if property_form.owned_with_mortgage?) || 0,
+          outstanding_mortgage: (property_entry_form.mortgage.strip if property_form.owned_with_mortgage?) || 0,
           percentage_owned:,
           subject_matter_of_dispute: (property_entry_form.house_in_dispute && smod_applicable?) || false,
         }
@@ -41,7 +41,7 @@ module Cfe
         partner_property_entry_form = PartnerPropertyEntryForm.from_session(@session_data)
         main_home = {
           value: partner_property_entry_form.house_value,
-          outstanding_mortgage: (partner_property_entry_form.mortgage if partner_property_form.owned_with_mortgage?) || 0,
+          outstanding_mortgage: (partner_property_entry_form.mortgage.strip if partner_property_form.owned_with_mortgage?) || 0,
           percentage_owned: partner_property_entry_form.percentage_owned,
           subject_matter_of_dispute: false,
         }

--- a/app/services/cfe/submit_assets_service.rb
+++ b/app/services/cfe/submit_assets_service.rb
@@ -16,7 +16,7 @@ module Cfe
       if asset_form.property_value.positive?
         second_property = {
           value: asset_form.property_value,
-          outstanding_mortgage: asset_form.property_mortgage.to_s.strip.to_f,
+          outstanding_mortgage: asset_form.property_mortgage.to_f,
           percentage_owned: asset_form.property_percentage_owned,
           subject_matter_of_dispute: (asset_form.property_in_dispute? && smod_applicable?) || false,
         }
@@ -32,7 +32,7 @@ module Cfe
                            end
         main_home = {
           value: property_entry_form.house_value,
-          outstanding_mortgage: (property_entry_form.mortgage.to_s.strip.to_f if property_form.owned_with_mortgage?) || 0,
+          outstanding_mortgage: (property_entry_form.mortgage.to_f if property_form.owned_with_mortgage?) || 0,
           percentage_owned:,
           subject_matter_of_dispute: (property_entry_form.house_in_dispute && smod_applicable?) || false,
         }
@@ -41,7 +41,7 @@ module Cfe
         partner_property_entry_form = PartnerPropertyEntryForm.from_session(@session_data)
         main_home = {
           value: partner_property_entry_form.house_value,
-          outstanding_mortgage: (partner_property_entry_form.mortgage.to_s.strip.to_f if partner_property_form.owned_with_mortgage?) || 0,
+          outstanding_mortgage: (partner_property_entry_form.mortgage.to_f if partner_property_form.owned_with_mortgage?) || 0,
           percentage_owned: partner_property_entry_form.percentage_owned,
           subject_matter_of_dispute: false,
         }

--- a/app/services/cfe_param_builders/employments.rb
+++ b/app/services/cfe_param_builders/employments.rb
@@ -11,13 +11,13 @@ module CfeParamBuilders
           receiving_only_statutory_sick_or_maternity_pay: applicant_form.employment_status == "receiving_statutory_pay",
           payments: Array.new(number_of_payments(employment_form)) do |index|
             {
-              gross: (employment_form.gross_income * multiplier(employment_form)).round(2),
-              tax: (-1 * employment_form.income_tax * multiplier(employment_form)).round(2),
-              national_insurance: (-1 * employment_form.national_insurance * multiplier(employment_form)).round(2),
+              gross: (employment_form.gross_income.to_f * multiplier(employment_form)).round(2),
+              tax: (-1 * employment_form.income_tax.to_f * multiplier(employment_form)).round(2),
+              national_insurance: (-1 * employment_form.national_insurance.to_f * multiplier(employment_form)).round(2),
               client_id: "id-#{index}",
               date: Date.current - period(employment_form, index),
               benefits_in_kind: 0,
-              net_employment_income: ((employment_form.gross_income - employment_form.income_tax - employment_form.national_insurance) * multiplier(employment_form)).round(2),
+              net_employment_income: ((employment_form.gross_income.to_f - employment_form.income_tax.to_f - employment_form.national_insurance.to_f) * multiplier(employment_form)).round(2),
             }
           end,
         },

--- a/app/services/cfe_param_builders/irregular_income.rb
+++ b/app/services/cfe_param_builders/irregular_income.rb
@@ -2,8 +2,8 @@ module CfeParamBuilders
   class IrregularIncome
     def self.call(form)
       [].tap do |payments|
-        payments << create_student_loan(form) if form.student_finance_value.positive?
-        payments << create_other_income(form) if form.other_value.positive?
+        payments << create_student_loan(form) if form.student_finance_value.to_f.positive?
+        payments << create_other_income(form) if form.other_value.to_f.positive?
       end
     end
 
@@ -11,7 +11,7 @@ module CfeParamBuilders
       {
         "income_type": "student_loan",
         "frequency": "annual",
-        "amount": form.student_finance_value,
+        "amount": form.student_finance_value.to_f,
       }
     end
 
@@ -19,7 +19,7 @@ module CfeParamBuilders
       {
         "income_type": "unspecified_source",
         "frequency": form.level_of_help == "controlled" ? "monthly" : "quarterly",
-        "amount": form.other_value,
+        "amount": form.other_value.to_f,
       }
     end
   end

--- a/app/services/cfe_param_builders/state_benefits.rb
+++ b/app/services/cfe_param_builders/state_benefits.rb
@@ -11,14 +11,14 @@ module CfeParamBuilders
         return [] if form.benefits.nil?
 
         form.benefits.map do |benefit|
-          build_benefit(benefit.benefit_frequency, benefit.benefit_amount, benefit.benefit_type)
+          build_benefit(benefit.benefit_frequency, benefit.benefit_amount.to_f, benefit.benefit_type)
         end
       end
 
       def housing_benefit(form)
         return [] unless form
 
-        [build_benefit(form.housing_benefit_frequency, form.housing_benefit_value, HOUSING_BENEFIT_TYPE)]
+        [build_benefit(form.housing_benefit_frequency, form.housing_benefit_value.to_f, HOUSING_BENEFIT_TYPE)]
       end
 
       def build_benefit(frequency, value, type)

--- a/spec/end_to_end/other_income_spec.rb
+++ b/spec/end_to_end/other_income_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "Controlled other income", type: :feature do
       irregular_transactions = stub_request(:post, %r{irregular_incomes\z}).with do |request|
         expected_payload = {
           payments: [
-            { income_type: "unspecified_source", frequency: "quarterly", amount: "500.0" },
+            { income_type: "unspecified_source", frequency: "quarterly", amount: 500.0 },
           ],
         }
         request.body == expected_payload.to_json
@@ -74,8 +74,8 @@ RSpec.describe "Controlled other income", type: :feature do
       irregular_transactions = stub_request(:post, %r{irregular_incomes\z}).with do |request|
         expected_payload = {
           payments: [
-            { income_type: "student_loan", frequency: "annual", amount: "100.0" },
-            { income_type: "unspecified_source", frequency: "monthly", amount: "500.0" },
+            { income_type: "student_loan", frequency: "annual", amount: 100.0 },
+            { income_type: "unspecified_source", frequency: "monthly", amount: 500.0 },
           ],
         }
         request.body == expected_payload.to_json

--- a/spec/end_to_end/with_partner_spec.rb
+++ b/spec/end_to_end/with_partner_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe "Certificated check without partner", type: :feature do
     create_partner_stub = stub_request(:post, %r{partner_financials\z}).with do |request|
       content = JSON.parse(request.body)
       expect(content["partner"]).to eq({ "date_of_birth" => "1973-02-15", "employed" => true })
-      expect(content["irregular_incomes"]).to eq([{ "income_type" => "unspecified_source", "frequency" => "quarterly", "amount" => "100.0" }])
+      expect(content["irregular_incomes"]).to eq([{ "income_type" => "unspecified_source", "frequency" => "quarterly", "amount" => 100.0 }])
       expect(content.dig("employments", 0, "payments", 0)).to eq({ "gross" => 1.0,
                                                                    "tax" => -0.0,
                                                                    "national_insurance" => -0.0,

--- a/spec/end_to_end/with_partner_spec.rb
+++ b/spec/end_to_end/with_partner_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "Certificated check without partner", type: :feature do
       expect(content).to eq({
         "properties" => {
           "main_home" => {
-            "outstanding_mortgage" => "1.0",
+            "outstanding_mortgage" => 1.0,
             "percentage_owned" => 1,
             "shared_with_housing_assoc" => false,
             "subject_matter_of_dispute" => false,

--- a/spec/end_to_end/with_partner_spec.rb
+++ b/spec/end_to_end/with_partner_spec.rb
@@ -39,13 +39,13 @@ RSpec.describe "Certificated check without partner", type: :feature do
       content = JSON.parse(request.body)
       expect(content["partner"]).to eq({ "date_of_birth" => "1973-02-15", "employed" => true })
       expect(content["irregular_incomes"]).to eq([{ "income_type" => "unspecified_source", "frequency" => "quarterly", "amount" => "100.0" }])
-      expect(content.dig("employments", 0, "payments", 0)).to eq({ "gross" => "1.0",
-                                                                   "tax" => "-0.0",
-                                                                   "national_insurance" => "-0.0",
+      expect(content.dig("employments", 0, "payments", 0)).to eq({ "gross" => 1.0,
+                                                                   "tax" => -0.0,
+                                                                   "national_insurance" => -0.0,
                                                                    "client_id" => "id-0",
                                                                    "date" => "2023-02-15",
                                                                    "benefits_in_kind" => 0,
-                                                                   "net_employment_income" => "1.0" })
+                                                                   "net_employment_income" => 1.0 })
       expect(content["regular_transactions"]).to eq(
         [{ "operation" => "credit", "category" => "friends_or_family", "frequency" => "weekly", "amount" => "200.0" }],
       )

--- a/spec/end_to_end/without_partner_spec.rb
+++ b/spec/end_to_end/without_partner_spec.rb
@@ -64,9 +64,9 @@ RSpec.describe "Certificated check without partner", type: :feature do
     create_benefits_stub = stub_request(:post, %r{state_benefits\z}).with do |request|
       content = JSON.parse(request.body)
       expect(content.dig("state_benefits", 0, "name")).to eq "A"
-      expect(content.dig("state_benefits", 0, "payments", 0)).to eq({ "date" => "2023-02-15", "amount" => "1.0", "client_id" => "" })
+      expect(content.dig("state_benefits", 0, "payments", 0)).to eq({ "date" => "2023-02-15", "amount" => 1.0, "client_id" => "" })
       expect(content.dig("state_benefits", 1, "name")).to eq "housing_benefit"
-      expect(content.dig("state_benefits", 1, "payments", 0)).to eq({ "date" => "2023-02-15", "amount" => "1.0", "client_id" => "" })
+      expect(content.dig("state_benefits", 1, "payments", 0)).to eq({ "date" => "2023-02-15", "amount" => 1.0, "client_id" => "" })
     end
 
     create_vehicles_stub = stub_request(:post, %r{vehicles\z}).with do |request|

--- a/spec/end_to_end/without_partner_spec.rb
+++ b/spec/end_to_end/without_partner_spec.rb
@@ -33,13 +33,13 @@ RSpec.describe "Certificated check without partner", type: :feature do
     create_employments_stub = stub_request(:post, %r{employments\z}).with do |request|
       content = JSON.parse(request.body)
       expect(content.dig("employment_income", 0, "payments", 0)).to eq({
-        "gross" => "1.0",
-        "tax" => "-0.0",
-        "national_insurance" => "-0.0",
+        "gross" => 1.0,
+        "tax" => -0.0,
+        "national_insurance" => -0.0,
         "client_id" => "id-0",
         "date" => "2023-02-15",
         "benefits_in_kind" => 0,
-        "net_employment_income" => "1.0",
+        "net_employment_income" => 1.0,
       })
     end
 

--- a/spec/end_to_end/without_partner_spec.rb
+++ b/spec/end_to_end/without_partner_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe "Certificated check without partner", type: :feature do
       expect(content).to eq({
         "properties" => {
           "main_home" => {
-            "outstanding_mortgage" => "1.0",
+            "outstanding_mortgage" => 1.0,
             "percentage_owned" => 1,
             "shared_with_housing_assoc" => false,
             "subject_matter_of_dispute" => false,

--- a/spec/end_to_end/without_partner_spec.rb
+++ b/spec/end_to_end/without_partner_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe "Certificated check without partner", type: :feature do
     create_irregular_transactions_stub = stub_request(:post, %r{irregular_incomes\z}).with do |request|
       expected_payload = {
         payments: [
-          { income_type: "student_loan", frequency: "annual", amount: "100.0" },
+          { income_type: "student_loan", frequency: "annual", amount: 100.0 },
         ],
       }
       request.body == expected_payload.to_json

--- a/spec/services/cfe/submit_assets_service_spec.rb
+++ b/spec/services/cfe/submit_assets_service_spec.rb
@@ -55,6 +55,44 @@ RSpec.describe Cfe::SubmitAssetsService do
       end
     end
 
+    context "when there is a full set of data, which includes property mortgage as a string including a trailing white space" do
+      let(:session_data) do
+        {
+          "property_owned" => "with_mortgage",
+          "house_value" => 234_234,
+          "mortgage" => 223_123,
+          "percentage_owned" => 80,
+          "house_in_dispute" => false,
+          "joint_ownership" => true,
+          "joint_percentage_owned" => 11,
+          "property_value" => 123,
+          "property_mortgage" => "2313 ",
+          "property_percentage_owned" => 54,
+          "savings" => 0,
+          "investments" => 0,
+          "valuables" => 0,
+          "in_dispute" => %w[savings investments valuables],
+        }
+      end
+
+      it "calls CFE with outstanding property mortgage converted to a float" do
+        expect(mock_connection).to receive(:create_properties).with(
+          cfe_assessment_id,
+          { additional_properties: [{ outstanding_mortgage: 2313, # this is converted to a float in submit_assests_service.rb
+                                      percentage_owned: 54,
+                                      shared_with_housing_assoc: false,
+                                      subject_matter_of_dispute: false,
+                                      value: 123 }],
+            main_home: { outstanding_mortgage: 223_123,
+                         percentage_owned: 91,
+                         shared_with_housing_assoc: false,
+                         subject_matter_of_dispute: false,
+                         value: 234_234 } },
+        )
+        described_class.call(mock_connection, cfe_assessment_id, session_data)
+      end
+    end
+
     context "when the client is asylum supported" do
       let(:session_data) do
         {

--- a/spec/services/cfe/submit_employment_income_service_spec.rb
+++ b/spec/services/cfe/submit_employment_income_service_spec.rb
@@ -49,5 +49,54 @@ RSpec.describe Cfe::SubmitEmploymentIncomeService do
         described_class.call(mock_connection, cfe_assessment_id, session_data)
       end
     end
+
+    # context "when there is a full set of data, which includes tax/income tax/gross income/national insurance as a string including a trailing white space" do
+    #   let(:session_data) do
+    #     {
+    #       "employment_status" => "in_work",
+    #       "frequency" => "monthly",
+    #       "gross_income" => "122 ", # this is converted to a float in employments.rb
+    #       "national_insurance" => "25 ", # this is converted to a float in employments.rb
+    #       "income_tax" => "18 ", # this is converted to a float in employments.rb
+    #     }
+    #   end
+
+    #   it "calls CFE with tax/income tax/gross income/national insurance converted to a float" do
+    #     expect(mock_connection).to receive(:create_employments).with(
+    #       cfe_assessment_id,
+    #       client_id: "ID",
+    #       name: "Job",
+    #       payments: [{
+    #         gross: 122.0,
+    #         tax: -18.0,
+    #         national_insurance: -25.0,
+    #         client_id: "id-0",
+    #         date: Date.today,
+    #         benefits_in_kind: 0,
+    #         net_employment_income: 79.0,
+    #       },
+    #                  {
+    #                    gross: 122.0,
+    #                    tax: -18.0,
+    #                    national_insurance: -25.0,
+    #                    client_id: "id-1",
+    #                    date: Time.zone.today - 1.month,
+    #                    benefits_in_kind: 0,
+    #                    net_employment_income: 79.0,
+    #                  },
+    #                  {
+    #                    gross: 122.0,
+    #                    tax: -18.0,
+    #                    national_insurance: -25.0,
+    #                    client_id: "id-2",
+    #                    date: Time.zone.today - 2.months,
+    #                    benefits_in_kind: 0,
+    #                    net_employment_income: 79.0,
+    #                  }],
+    #       receiving_only_statutory_sick_or_maternity_pay: false,
+    #     )
+    #     described_class.call(mock_connection, cfe_assessment_id, session_data)
+    #   end
+    # end
   end
 end

--- a/spec/services/cfe/submit_employment_income_service_spec.rb
+++ b/spec/services/cfe/submit_employment_income_service_spec.rb
@@ -49,54 +49,5 @@ RSpec.describe Cfe::SubmitEmploymentIncomeService do
         described_class.call(mock_connection, cfe_assessment_id, session_data)
       end
     end
-
-    # context "when there is a full set of data, which includes tax/income tax/gross income/national insurance as a string including a trailing white space" do
-    #   let(:session_data) do
-    #     {
-    #       "employment_status" => "in_work",
-    #       "frequency" => "monthly",
-    #       "gross_income" => "122 ", # this is converted to a float in employments.rb
-    #       "national_insurance" => "25 ", # this is converted to a float in employments.rb
-    #       "income_tax" => "18 ", # this is converted to a float in employments.rb
-    #     }
-    #   end
-
-    #   it "calls CFE with tax/income tax/gross income/national insurance converted to a float" do
-    #     expect(mock_connection).to receive(:create_employments).with(
-    #       cfe_assessment_id,
-    #       client_id: "ID",
-    #       name: "Job",
-    #       payments: [{
-    #         gross: 122.0,
-    #         tax: -18.0,
-    #         national_insurance: -25.0,
-    #         client_id: "id-0",
-    #         date: Date.today,
-    #         benefits_in_kind: 0,
-    #         net_employment_income: 79.0,
-    #       },
-    #                  {
-    #                    gross: 122.0,
-    #                    tax: -18.0,
-    #                    national_insurance: -25.0,
-    #                    client_id: "id-1",
-    #                    date: Time.zone.today - 1.month,
-    #                    benefits_in_kind: 0,
-    #                    net_employment_income: 79.0,
-    #                  },
-    #                  {
-    #                    gross: 122.0,
-    #                    tax: -18.0,
-    #                    national_insurance: -25.0,
-    #                    client_id: "id-2",
-    #                    date: Time.zone.today - 2.months,
-    #                    benefits_in_kind: 0,
-    #                    net_employment_income: 79.0,
-    #                  }],
-    #       receiving_only_statutory_sick_or_maternity_pay: false,
-    #     )
-    #     described_class.call(mock_connection, cfe_assessment_id, session_data)
-    #   end
-    # end
   end
 end


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-826)

## What changed and why

Relates to this [Runtime Error](https://ministryofjustice.sentry.io/issues/4058281497/?project=4504177640275968&referrer=slack) where if a user leaves a trailing white space after the number on the 'outstanding mortgage' field they can't see the results page.

## Guidance to review

Chosen to tidy the data we send to CFE instead of form validation, for a better user journey. 

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
