### PR TITLE
EL-828: Use correct values for pensioner disregard table when there is a partner

### DIFF
--- a/app/models/calculation_result.rb
+++ b/app/models/calculation_result.rb
@@ -172,9 +172,10 @@ class CalculationResult
   end
 
   def pensioner_disregard_rows
-    total_capital = api_response.dig(:result_summary, :capital, :total_capital) +
-      api_response.dig(:result_summary, :partner_capital, :total_capital)
-    disregarded = api_response.dig(:result_summary, :capital, :pensioner_disregard_applied)
+    total_capital = api_response.dig(:result_summary, :capital, :total_capital_with_smod) +
+      api_response.dig(:result_summary, :partner_capital, :total_capital_with_smod)
+    disregarded = api_response.dig(:result_summary, :capital, :pensioner_disregard_applied) +
+      api_response.dig(:result_summary, :partner_capital, :pensioner_disregard_applied)
     {
       total_capital: monetise(total_capital),
       pensioner_capital_disregard: monetise(-disregarded),

--- a/spec/views/results_page/pensioner_content_spec.rb
+++ b/spec/views/results_page/pensioner_content_spec.rb
@@ -38,6 +38,11 @@ RSpec.describe "estimates/show.html.slim" do
       it "shows a separate pensioner disregard table" do
         expect(rendered).to include '<caption class="govuk-table__caption govuk-table__caption--m">Pensioner disregard'
       end
+
+      it "sums up client and partner values for the separate pensioner disregard table" do
+        # 123 + 234 = 357. 456 + 567 = 1023.
+        expect(page_text).to include("Total client and partner disposable capital £1,023.00 Pensioner disregard -£357.00")
+      end
     end
 
     context "when client has a partner and only the partner has had pensioner disregard applied" do


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-828)

## What changed and why

- We weren't including the pensioner disregard values applied to partner capital in the pensioner disregard table
- Also we were using `total_capital` rather than `total_capital_with_smod` in the first line, which was sometimes showing incorrect values (because SMOD has already been deducted by the time this table is displayed)

## Guidance to review

I have asked the CFE team if they can do the maths for us to save us doing `+`, and they will do this as a low-priority thing. In the meantime we will do the `+`.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
