### PR TITLE
EL-815: Send BigDecimals as numbers to CFE

### DIFF
--- a/app/lib/cfe_connection.rb
+++ b/app/lib/cfe_connection.rb
@@ -78,7 +78,7 @@ private
 
   def create_record(assessment_id, record_type, record_data)
     url = "/assessments/#{assessment_id}/#{record_type}"
-    response = cfe_connection.post url, record_data
+    response = cfe_connection.post url, format_json(record_data)
     validate_api_response(response, url)
   end
 
@@ -104,6 +104,15 @@ private
       faraday.response :json
 
       faraday.adapter :net_http_persistent
+    end
+  end
+
+  def format_json(hash)
+    # BigDecimal#as_json returns a string, and we want numbers to be sent to
+    # CFE as numbers. So we seek out all decimals and convert them to floats
+    # as we build the payload.
+    hash.deep_transform_values do |value|
+      value.is_a?(BigDecimal) ? value.to_f : value
     end
   end
 end

--- a/spec/end_to_end/other_income_spec.rb
+++ b/spec/end_to_end/other_income_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "Controlled other income", type: :feature do
       irregular_transactions = stub_request(:post, %r{irregular_incomes\z}).with do |request|
         expected_payload = {
           payments: [
-            { income_type: "unspecified_source", frequency: "quarterly", amount: "500.0" },
+            { income_type: "unspecified_source", frequency: "quarterly", amount: 500.0 },
           ],
         }
         request.body == expected_payload.to_json
@@ -33,8 +33,8 @@ RSpec.describe "Controlled other income", type: :feature do
       regular_transactions = stub_request(:post, %r{regular_transactions\z}).with do |request|
         expected_payload = {
           "regular_transactions": [
-            { "operation": "credit", "category": "friends_or_family", "frequency": "weekly", "amount": "200.0" },
-            { "operation": "credit", "category": "maintenance_in", "frequency": "two_weekly", "amount": "300.0" },
+            { "operation": "credit", "category": "friends_or_family", "frequency": "weekly", "amount": 200.0 },
+            { "operation": "credit", "category": "maintenance_in", "frequency": "two_weekly", "amount": 300.0 },
           ],
         }
         request.body == expected_payload.to_json
@@ -74,8 +74,8 @@ RSpec.describe "Controlled other income", type: :feature do
       irregular_transactions = stub_request(:post, %r{irregular_incomes\z}).with do |request|
         expected_payload = {
           payments: [
-            { income_type: "student_loan", frequency: "annual", amount: "100.0" },
-            { income_type: "unspecified_source", frequency: "monthly", amount: "500.0" },
+            { income_type: "student_loan", frequency: "annual", amount: 100.0 },
+            { income_type: "unspecified_source", frequency: "monthly", amount: 500.0 },
           ],
         }
         request.body == expected_payload.to_json
@@ -84,8 +84,8 @@ RSpec.describe "Controlled other income", type: :feature do
       regular_transactions = stub_request(:post, %r{regular_transactions\z}).with do |request|
         expected_payload = {
           "regular_transactions": [
-            { "operation": "credit", "category": "friends_or_family", "frequency": "weekly", "amount": "200.0" },
-            { "operation": "credit", "category": "maintenance_in", "frequency": "two_weekly", "amount": "300.0" },
+            { "operation": "credit", "category": "friends_or_family", "frequency": "weekly", "amount": 200.0 },
+            { "operation": "credit", "category": "maintenance_in", "frequency": "two_weekly", "amount": 300.0 },
           ],
         }
         request.body == expected_payload.to_json

--- a/spec/end_to_end/passporting_spec.rb
+++ b/spec/end_to_end/passporting_spec.rb
@@ -32,8 +32,8 @@ RSpec.describe "Certificated passported check", type: :feature do
       expect(content).to eq({
         "vehicles" => [
           {
-            "value" => "1.0",
-            "loan_amount_outstanding" => "5.0",
+            "value" => 1.0,
+            "loan_amount_outstanding" => 5.0,
             "date_of_purchase" => "2021-02-15",
             "in_regular_use" => false,
             "subject_matter_of_dispute" => false,
@@ -45,7 +45,7 @@ RSpec.describe "Certificated passported check", type: :feature do
     create_capitals_stub = stub_request(:post, %r{capitals\z}).with do |request|
       expected_payload = {
         "bank_accounts": [],
-        "non_liquid_capital": [{ "value": "800.0", "description": "Non Liquid Asset", "subject_matter_of_dispute": false }],
+        "non_liquid_capital": [{ "value": 800.0, "description": "Non Liquid Asset", "subject_matter_of_dispute": false }],
       }
       request.body == expected_payload.to_json
     end

--- a/spec/end_to_end/with_partner_spec.rb
+++ b/spec/end_to_end/with_partner_spec.rb
@@ -25,11 +25,11 @@ RSpec.describe "Certificated check without partner", type: :feature do
       expect(content).to eq({
         "properties" => {
           "main_home" => {
-            "outstanding_mortgage" => "1.0",
+            "outstanding_mortgage" => 1.0,
             "percentage_owned" => 1,
             "shared_with_housing_assoc" => false,
             "subject_matter_of_dispute" => false,
-            "value" => "1.0",
+            "value" => 1.0,
           },
         },
       })
@@ -38,23 +38,23 @@ RSpec.describe "Certificated check without partner", type: :feature do
     create_partner_stub = stub_request(:post, %r{partner_financials\z}).with do |request|
       content = JSON.parse(request.body)
       expect(content["partner"]).to eq({ "date_of_birth" => "1973-02-15", "employed" => true })
-      expect(content["irregular_incomes"]).to eq([{ "income_type" => "unspecified_source", "frequency" => "quarterly", "amount" => "100.0" }])
-      expect(content.dig("employments", 0, "payments", 0)).to eq({ "gross" => "1.0",
-                                                                   "tax" => "-0.0",
-                                                                   "national_insurance" => "-0.0",
+      expect(content["irregular_incomes"]).to eq([{ "income_type" => "unspecified_source", "frequency" => "quarterly", "amount" => 100.0 }])
+      expect(content.dig("employments", 0, "payments", 0)).to eq({ "gross" => 1.0,
+                                                                   "tax" => 0.0,
+                                                                   "national_insurance" => 0.0,
                                                                    "client_id" => "id-0",
                                                                    "date" => "2023-02-15",
                                                                    "benefits_in_kind" => 0,
-                                                                   "net_employment_income" => "1.0" })
+                                                                   "net_employment_income" => 1.0 })
       expect(content["regular_transactions"]).to eq(
-        [{ "operation" => "credit", "category" => "friends_or_family", "frequency" => "weekly", "amount" => "200.0" }],
+        [{ "operation" => "credit", "category" => "friends_or_family", "frequency" => "weekly", "amount" => 200.0 }],
       )
       expect(content["state_benefits"].length).to eq 2
       expect(content["capitals"]).to eq({
-        "bank_accounts" => [], "non_liquid_capital" => [{ "value" => "700.0", "description" => "Non Liquid Asset", "subject_matter_of_dispute" => false }]
+        "bank_accounts" => [], "non_liquid_capital" => [{ "value" => 700.0, "description" => "Non Liquid Asset", "subject_matter_of_dispute" => false }]
       })
       expect(content["vehicles"]).to eq(
-        [{ "value" => "1.0", "loan_amount_outstanding" => 0, "date_of_purchase" => "2021-02-15", "in_regular_use" => false, "subject_matter_of_dispute" => false }],
+        [{ "value" => 1.0, "loan_amount_outstanding" => 0, "date_of_purchase" => "2021-02-15", "in_regular_use" => false, "subject_matter_of_dispute" => false }],
       )
       expect(content["dependants"]).to eq(
         [{ "date_of_birth" => "2012-02-15", "in_full_time_education" => true, "relationship" => "child_relative", "monthly_income" => 0, "assets_value" => 0 }],

--- a/spec/end_to_end/without_partner_spec.rb
+++ b/spec/end_to_end/without_partner_spec.rb
@@ -33,20 +33,20 @@ RSpec.describe "Certificated check without partner", type: :feature do
     create_employments_stub = stub_request(:post, %r{employments\z}).with do |request|
       content = JSON.parse(request.body)
       expect(content.dig("employment_income", 0, "payments", 0)).to eq({
-        "gross" => "1.0",
-        "tax" => "-0.0",
-        "national_insurance" => "-0.0",
+        "gross" => 1.0,
+        "tax" => 0.0,
+        "national_insurance" => 0.0,
         "client_id" => "id-0",
         "date" => "2023-02-15",
         "benefits_in_kind" => 0,
-        "net_employment_income" => "1.0",
+        "net_employment_income" => 1.0,
       })
     end
 
     create_irregular_transactions_stub = stub_request(:post, %r{irregular_incomes\z}).with do |request|
       expected_payload = {
         payments: [
-          { income_type: "student_loan", frequency: "annual", amount: "100.0" },
+          { income_type: "student_loan", frequency: "annual", amount: 100.0 },
         ],
       }
       request.body == expected_payload.to_json
@@ -55,7 +55,7 @@ RSpec.describe "Certificated check without partner", type: :feature do
     create_regular_transactions_stub = stub_request(:post, %r{regular_transactions\z}).with do |request|
       expected_payload = {
         "regular_transactions": [
-          { "operation": "credit", "category": "friends_or_family", "frequency": "weekly", "amount": "200.0" },
+          { "operation": "credit", "category": "friends_or_family", "frequency": "weekly", "amount": 200.0 },
         ],
       }
       request.body == expected_payload.to_json
@@ -64,9 +64,9 @@ RSpec.describe "Certificated check without partner", type: :feature do
     create_benefits_stub = stub_request(:post, %r{state_benefits\z}).with do |request|
       content = JSON.parse(request.body)
       expect(content.dig("state_benefits", 0, "name")).to eq "A"
-      expect(content.dig("state_benefits", 0, "payments", 0)).to eq({ "date" => "2023-02-15", "amount" => "1.0", "client_id" => "" })
+      expect(content.dig("state_benefits", 0, "payments", 0)).to eq({ "date" => "2023-02-15", "amount" => 1.0, "client_id" => "" })
       expect(content.dig("state_benefits", 1, "name")).to eq "housing_benefit"
-      expect(content.dig("state_benefits", 1, "payments", 0)).to eq({ "date" => "2023-02-15", "amount" => "1.0", "client_id" => "" })
+      expect(content.dig("state_benefits", 1, "payments", 0)).to eq({ "date" => "2023-02-15", "amount" => 1.0, "client_id" => "" })
     end
 
     create_vehicles_stub = stub_request(:post, %r{vehicles\z}).with do |request|
@@ -74,8 +74,8 @@ RSpec.describe "Certificated check without partner", type: :feature do
       expect(content).to eq({
         "vehicles" => [
           {
-            "value" => "1.0",
-            "loan_amount_outstanding" => "5.0",
+            "value" => 1.0,
+            "loan_amount_outstanding" => 5.0,
             "date_of_purchase" => "2021-02-15",
             "in_regular_use" => false,
             "subject_matter_of_dispute" => false,
@@ -89,11 +89,11 @@ RSpec.describe "Certificated check without partner", type: :feature do
       expect(content).to eq({
         "properties" => {
           "main_home" => {
-            "outstanding_mortgage" => "1.0",
+            "outstanding_mortgage" => 1.0,
             "percentage_owned" => 1,
             "shared_with_housing_assoc" => false,
             "subject_matter_of_dispute" => false,
-            "value" => "1.0",
+            "value" => 1.0,
           },
         },
       })
@@ -102,7 +102,7 @@ RSpec.describe "Certificated check without partner", type: :feature do
     create_capitals_stub = stub_request(:post, %r{capitals\z}).with do |request|
       expected_payload = {
         "bank_accounts": [],
-        "non_liquid_capital": [{ "value": "700.0", "description": "Non Liquid Asset", "subject_matter_of_dispute": false }],
+        "non_liquid_capital": [{ "value": 700.0, "description": "Non Liquid Asset", "subject_matter_of_dispute": false }],
       }
       request.body == expected_payload.to_json
     end


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-815)

## What changed and why

We now transform BigDecimals to floats in our CFE payloads so that as JSON they get rendered as numbers rather than strings.

## Guidance to review

I had thought we could use activesupport-json_encoder for this, but it turns out that doesn't work for Rails 5+. Another option was to monkey-patch BigDecimal, but that might have had unexpected consequences in other places, so in the end I opted to add a transformation to CFE payloads to turn all decimals into floats. I don't _think_ we ever use big enough numbers (given we restrict to 2 decimal places) that we could ever be troubled by floating point imprecision here.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
