### PR TITLE
EL-833: Check your answers matter type text

### DIFF
--- a/app/lib/check_answers_fields.yml
+++ b/app/lib/check_answers_fields.yml
@@ -41,6 +41,7 @@ sections:
             type: select
             screen: matter_type
             change_link: true
+            alt_attribute: level_of_help
       - screen: asylum_support
         label: asylum_support
         fields:

--- a/app/views/estimates/_check_answers_table.html.slim
+++ b/app/views/estimates/_check_answers_table.html.slim
@@ -50,9 +50,10 @@
                     screen_to_link_to: (field.screen_to_link_to if change_links),
                     disputed_asset: field.disputed?
         - when "select"
+          - value_key = "#{field.value || 'not_provided'}#{"_#{field.alt_value}" if field.alt_value}"
           = render "check_answer",
                     label_text: t("estimates.check_answers.#{field.label}"),
-                    value_text: t("estimates.check_answers.#{field.label}_options.#{field.value || 'not_provided'}"),
+                    value_text: t("estimates.check_answers.#{field.label}_options.#{value_key}"),
                     screen_to_link_to: (field.screen_to_link_to if change_links),
                     disputed_asset: field.disputed?
         - when "money_with_frequency"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1155,10 +1155,13 @@ en:
       about_the_case_fields:
         proceeding_type: Type of matter
         proceeding_type_options:
-          IM030: "Immigration in the Upper Tribunal"
-          IA031: "Asylum in the Upper Tribunal"
-          SE003: "Another legal matter"
-          DA001: "Domestic abuse"
+          IM030_certificated: Immigration in the Upper Tribunal
+          IM030_controlled: Immigration in the First-tier Tribunal
+          IA031_certificated: Asylum in the Upper Tribunal
+          IA031_controlled: Another immigration or asylum matter
+          SE003_certificated: Another legal matter
+          SE003_controlled: Another legal matter
+          DA001_certificated: Domestic abuse
           not_provided: "Not provided"
       about_your_client: About your client
       about_partner: About your client's partner

--- a/spec/views/check_answers_page/client_content/special_client_types/asylum_and_immigration_spec.rb
+++ b/spec/views/check_answers_page/client_content/special_client_types/asylum_and_immigration_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "estimates/check_answers.html.slim" do
   describe "immigration and asylum proceedings", :asylum_and_immigration_flag do
     let(:session_data) do
       build(:minimal_complete_session,
-            level_of_help: "controlled",
+            level_of_help:,
             legacy_proceeding_type: nil,
             proceeding_type:,
             asylum_support:)
@@ -23,21 +23,33 @@ RSpec.describe "estimates/check_answers.html.slim" do
       let(:proceeding_type) { "IM030" }
       let(:asylum_support) { true }
 
-      it "renders the correct case matter type" do
-        expect(page_text).to include("Type of matterImmigration in the Upper Tribunal")
-      end
+      context "when level of help is controlled" do
+        let(:level_of_help) { "controlled" }
 
-      context "and asylum support is true" do
-        it "renders the correct content" do
-          expect(page_text).to include("Receives asylum supportYes")
+        it "renders the correct case matter type" do
+          expect(page_text).to include("Type of matterImmigration in the First-tier Tribunal")
+        end
+
+        context "and asylum support is true" do
+          it "renders the correct content" do
+            expect(page_text).to include("Receives asylum supportYes")
+          end
+        end
+
+        context "and asylum support is false" do
+          let(:asylum_support) { false }
+
+          it "renders the correct content" do
+            expect(page_text).to include("Receives asylum supportNo")
+          end
         end
       end
 
-      context "and asylum support is false" do
-        let(:asylum_support) { false }
+      context "when level of help is certificated" do
+        let(:level_of_help) { "certificated" }
 
-        it "renders the correct content" do
-          expect(page_text).to include("Receives asylum supportNo")
+        it "renders the correct case matter type" do
+          expect(page_text).to include("Type of matterImmigration in the Upper Tribunal")
         end
       end
     end
@@ -46,21 +58,33 @@ RSpec.describe "estimates/check_answers.html.slim" do
       let(:proceeding_type) { "IA031" }
       let(:asylum_support) { true }
 
-      it "renders the correct case matter type" do
-        expect(page_text).to include("Type of matterAsylum in the Upper Tribunal")
-      end
+      context "when level of help is controlled" do
+        let(:level_of_help) { "controlled" }
 
-      context "and asylum support is true" do
-        it "renders the correct content" do
-          expect(page_text).to include("Receives asylum supportYes")
+        it "renders the correct case matter type" do
+          expect(page_text).to include("Type of matterAnother immigration or asylum matter")
         end
-      end
 
-      context "and asylum support is false" do
-        let(:asylum_support) { false }
+        context "and asylum support is true" do
+          it "renders the correct content" do
+            expect(page_text).to include("Receives asylum supportYes")
+          end
+        end
 
-        it "renders the correct content" do
-          expect(page_text).to include("Receives asylum supportNo")
+        context "and asylum support is false" do
+          let(:asylum_support) { false }
+
+          it "renders the correct content" do
+            expect(page_text).to include("Receives asylum supportNo")
+          end
+        end
+
+        context "when level of help is certificated" do
+          let(:level_of_help) { "certificated" }
+
+          it "renders the correct case matter type" do
+            expect(page_text).to include("Type of matterAsylum in the Upper Tribunal")
+          end
         end
       end
     end


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-833)

## What changed and why

If a check answers select field has an `alt_attribute` key, use that to construct the I18n key for the value text. That way we can use both the level of help and the proceeding type to determine what text to show for the 'What type of matter is this?' check answers field.

## Guidance to review

<!-- anything useful to let the reviewer know? -->

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
