### PR TITLE
EL-835: no-analytics mode

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -23,7 +23,7 @@ private
 
   def track(event_type, page:)
     AnalyticsService.call(event_type:,
-                          browser_id: cookies[BROWSER_ID_COOKIE],
+                          cookies:,
                           assessment_code:,
                           page:)
   end

--- a/app/controllers/cookies_controller.rb
+++ b/app/controllers/cookies_controller.rb
@@ -2,6 +2,7 @@ class CookiesController < ApplicationController
   before_action :track_page_view, only: :show
 
   COOKIE_CHOICE_NAME = :optional_cookie_choice
+  NO_ANALYTICS_MODE = :no_analytics_mode
   def update
     choice = params[:cookies] == "accept" ? "accepted" : "rejected"
     cookies[COOKIE_CHOICE_NAME] = { value: choice, expires: 1.year, httponly: true, secure: Rails.env.production? }
@@ -11,6 +12,11 @@ class CookiesController < ApplicationController
   end
 
   def show; end
+
+  def no_analytics_mode
+    cookies[NO_ANALYTICS_MODE] = { value: "true", httponly: true, secure: Rails.env.production? }
+    redirect_to root_path
+  end
 
 private
 

--- a/app/controllers/estimate_flow_controller.rb
+++ b/app/controllers/estimate_flow_controller.rb
@@ -32,6 +32,6 @@ protected
   end
 
   def track_choices(form)
-    ChoiceAnalyticsService.call(form, assessment_code, cookies[BROWSER_ID_COOKIE])
+    ChoiceAnalyticsService.call(form, assessment_code, cookies)
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -52,4 +52,10 @@ module ApplicationHelper
       estimate_build_estimate_path(assessment_code, step)
     end
   end
+
+  def enable_google_analytics(cookies)
+    ENV["GOOGLE_TAG_MANAGER_ID"].present? &&
+      cookies[CookiesController::COOKIE_CHOICE_NAME] == "accepted" &&
+      !cookies[CookiesController::NO_ANALYTICS_MODE]
+  end
 end

--- a/app/services/analytics_service.rb
+++ b/app/services/analytics_service.rb
@@ -1,6 +1,9 @@
 class AnalyticsService
   class << self
-    def call(event_type:, page:, assessment_code:, browser_id:)
+    def call(event_type:, page:, assessment_code:, cookies:)
+      return if cookies[CookiesController::NO_ANALYTICS_MODE]
+
+      browser_id = cookies[ApplicationController::BROWSER_ID_COOKIE]
       AnalyticsEvent.create!(
         event_type:,
         page:,

--- a/app/services/choice_analytics_service.rb
+++ b/app/services/choice_analytics_service.rb
@@ -1,5 +1,8 @@
 class ChoiceAnalyticsService
-  def self.call(form, assessment_code, browser_id)
+  def self.call(form, assessment_code, cookies)
+    return if cookies[CookiesController::NO_ANALYTICS_MODE]
+
+    browser_id = cookies[ApplicationController::BROWSER_ID_COOKIE]
     # For the most part, our analytics data should _only_ contain information
     # about the pages viewed by users, not the content of any forms they make.
 

--- a/app/views/layouts/_analytics_body.html.slim
+++ b/app/views/layouts/_analytics_body.html.slim
@@ -1,4 +1,4 @@
-- if ENV["GOOGLE_TAG_MANAGER_ID"].present? && cookies[CookiesController::COOKIE_CHOICE_NAME] == "accepted"
+- if enable_google_analytics(cookies)
   /! Google Tag Manager (noscript)
   noscript
     iframe[src="https://www.googletagmanager.com/ns.html?id=#{ENV["GOOGLE_TAG_MANAGER_ID"]}"

--- a/app/views/layouts/_analytics_head.html.slim
+++ b/app/views/layouts/_analytics_head.html.slim
@@ -1,4 +1,4 @@
-- if ENV["GOOGLE_TAG_MANAGER_ID"].present? && cookies[CookiesController::COOKIE_CHOICE_NAME] == "accepted"
+- if enable_google_analytics(cookies)
   /! Google Tag Manager
   javascript:
     (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':

--- a/app/views/layouts/_footer.html.slim
+++ b/app/views/layouts/_footer.html.slim
@@ -1,5 +1,7 @@
 footer.govuk-footer.no-print role="contentinfo"
   .govuk-width-container
+    - if cookies[CookiesController::NO_ANALYTICS_MODE]
+      strong.govuk-tag = t("layouts.application.footer.no_analytics")
     .govuk-footer__meta
       .govuk-footer__meta-item.govuk-footer__meta-item--grow
 

--- a/config/locales/en.layouts.yml
+++ b/config/locales/en.layouts.yml
@@ -14,3 +14,4 @@ en:
         open_gov_link_text: Open Government Licence v3.0
         copyright: Crown copyright
         accessibility: Accessibility statement
+        no_analytics: No-analytics mode

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,4 +34,5 @@ Rails.application.routes.draw do
   resource :accessibility, only: :show
 
   get "/health-including-dependents", to: "status#health"
+  get "/no-analytics", to: "cookies#no_analytics_mode"
 end

--- a/spec/features/no_analytics_mode_spec.rb
+++ b/spec/features/no_analytics_mode_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.describe "No-analytics mode", type: :feature do
+  context "when I have not enabled no-analytics mode" do
+    scenario "I visit the home page" do
+      visit root_path
+      expect(page).not_to have_content "No-analytics mode"
+      expect(AnalyticsEvent.count).to eq 1
+    end
+  end
+
+  scenario "I enable no-analytics mode" do
+    visit no_analytics_path
+    expect(page).to have_current_path "/"
+    expect(page).to have_content "No-analytics mode"
+    expect(AnalyticsEvent.count).to eq 0
+  end
+end

--- a/spec/services/analytics_service_spec.rb
+++ b/spec/services/analytics_service_spec.rb
@@ -5,7 +5,13 @@ RSpec.describe AnalyticsService do
     it "handles errors without crashing" do
       expect(ErrorService).to receive(:call)
 
-      expect { described_class.call(event_type: nil, page: "some_page", assessment_code: nil, browser_id: nil) }.not_to raise_error
+      expect { described_class.call(event_type: nil, page: "some_page", assessment_code: nil, cookies: {}) }.not_to raise_error
+    end
+
+    it "respects no-analytics mode" do
+      cookies = { CookiesController::NO_ANALYTICS_MODE => "true" }
+      described_class.call(event_type: nil, page: "some_page", assessment_code: nil, cookies:)
+      expect(AnalyticsEvent.count).to eq 0
     end
   end
 end

--- a/spec/services/choice_analytics_service_spec.rb
+++ b/spec/services/choice_analytics_service_spec.rb
@@ -3,11 +3,18 @@ require "rails_helper"
 RSpec.describe ChoiceAnalyticsService do
   describe ".call" do
     let(:form) { LevelOfHelpForm.new }
+    let(:assessment_code) { "assessment_code" }
 
     it "handles errors without crashing" do
       expect(ErrorService).to receive(:call)
       allow(AnalyticsEvent).to receive(:create!).and_raise "Error!"
-      expect { described_class.call(form, "assessment_code", nil) }.not_to raise_error
+      expect { described_class.call(form, assessment_code, {}) }.not_to raise_error
+    end
+
+    it "respects no-analytics mode" do
+      cookies = { CookiesController::NO_ANALYTICS_MODE => "true" }
+      described_class.call(form, assessment_code, cookies)
+      expect(AnalyticsEvent.count).to eq 0
     end
   end
 end


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-835)

## What changed and why

Create a new "no-analytics mode" a state, marked by a cookie, in which no analytics data will be stored and no Google Analytics will be generated. Visiting a new URL will cause this mode to be entered, and a badge to be shown in the footer. The user will stay in this mode for the duration of their browser session. 

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
