### PR TITLE
EL-834: Disable staging geckoboard

### DIFF
--- a/helm_deploy/laa-estimate-eligibility/values/staging.yaml
+++ b/helm_deploy/laa-estimate-eligibility/values/staging.yaml
@@ -61,4 +61,4 @@ geckoboard:
   allMetricsDataset: "ccq_all_metrics_staging"
   lastPagesDataset: "ccq_last_pages_staging"
   validationsDataset: "ccq_validations_staging"
-  enabled: enabled
+  enabled: not_enabled


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-834)

## What changed and why

Stop sending staging analytics data to geckoboard. This is because we have never yet used staging data on Geckoboard, and don't have any boards set up for it. Furthermore, we're about to start switching off the staging database at night, so the nightly job that's supposed to push data to Geckoboard will fail if it tries to run. So we might as well stop it trying.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
