### PR TITLE
Ensure vehicle SMOD is never nil

### DIFF
--- a/app/services/cfe_param_builders/vehicles.rb
+++ b/app/services/cfe_param_builders/vehicles.rb
@@ -7,7 +7,7 @@ module CfeParamBuilders
           loan_amount_outstanding: form.vehicle_pcp ? form.vehicle_finance : 0,
           date_of_purchase: form.vehicle_over_3_years_ago ? 4.years.ago.to_date : 2.years.ago.to_date,
           in_regular_use: form.vehicle_in_regular_use,
-          subject_matter_of_dispute: in_dispute,
+          subject_matter_of_dispute: in_dispute || false,
         },
       ]
     end


### PR DESCRIPTION
We have an issue live in production where client vehicle subject_matter_of_dispute is being sent to CFE as nil when the client has a vehicle and the case is upper tribunal (because we don't ask the SMOD question in that scenario so the relevant value isn't set). At some point CFE made that field a mandatory boolean. This ensures that if we have a `nil` value we tell CFE it is `false` as a workaround.