### PR TITLE
EL-849: Hint to mobile browsers that soft keypad should include decimal points

### DIFF
--- a/app/views/shared/_money_input.html.slim
+++ b/app/views/shared/_money_input.html.slim
@@ -4,5 +4,4 @@
                         label: { text: label_text, size: },
                         prefix_text: BuildEstimatesHelper::POUND,
                         value: decimal_as_money_string(form, field),
-                        pattern: "[0-9]*",
-                        inputmode: "numeric"
+                        inputmode: "decimal"

--- a/app/views/shared/_money_input_with_hint.html.slim
+++ b/app/views/shared/_money_input_with_hint.html.slim
@@ -5,5 +5,4 @@
                         label: { text: label_text, size: "m" },
                         prefix_text: BuildEstimatesHelper::POUND,
                         value: decimal_as_money_string(form, field),
-                        pattern: "[0-9]*",
-                        inputmode: "numeric"
+                        inputmode: "decimal"


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-849)

## What changed and why

Fix issue where on mobile you aren't allowed to enter a "." on money fields

## Guidance to review

- The "inputmode" attribute hints to mobiles what sort of keypad to display
- The "pattern" is used for client-side validation, but since we don't _do_ that it's redundant so I've removed it.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
