### PR TITLE
EL-888: Keyboard input for percentages on mobile screen

### DIFF
--- a/app/views/estimate_flow/forms/_assets.html.slim
+++ b/app/views/estimate_flow/forms/_assets.html.slim
@@ -20,12 +20,12 @@
             field: :property_mortgage,
             width: 5,
             label_text: t("estimate_flow.#{i18n_key}.property.mortgage.label")
-    = form.govuk_text_field :property_percentage_owned,
+    = render "shared/percentage_input_with_hint",
+            form:,
+            field: :property_percentage_owned,
             width: 5,
-            suffix_text: "%",
-            value: integer_field_value(form, :property_percentage_owned),
-            label: { text: t("estimate_flow.#{i18n_key}.property.percentage_owned.input") },
-            hint: { text: t("estimate_flow.#{i18n_key}.property.percentage_owned.input_hint") }
+            label_text: t("estimate_flow.#{i18n_key}.property.percentage_owned.input"),
+            hint_text: t("estimate_flow.#{i18n_key}.property.percentage_owned.input_hint")
 
     - if show_smod_content
       .govuk-form-group

--- a/app/views/estimate_flow/forms/_assets.html.slim
+++ b/app/views/estimate_flow/forms/_assets.html.slim
@@ -20,7 +20,7 @@
             field: :property_mortgage,
             width: 5,
             label_text: t("estimate_flow.#{i18n_key}.property.mortgage.label")
-    = render "shared/percentage_input_with_hint",
+    = render "shared/percentage_input",
             form:,
             field: :property_percentage_owned,
             width: 5,

--- a/app/views/estimate_flow/forms/_property_entry.html.slim
+++ b/app/views/estimate_flow/forms/_property_entry.html.slim
@@ -19,12 +19,13 @@
              label_text: t("estimate_flow.#{i18n_key}.mortgage.input"),
              hint_text: t("estimate_flow.#{i18n_key}.mortgage.input_hint")
 
-  = form.govuk_text_field :percentage_owned,
-                            width: 3,
-                            suffix_text: "%",
-                            value: integer_field_value(form, :percentage_owned),
-                            label: { text: t("estimate_flow.#{i18n_key}.percentage_owned.input"), size: "m" },
-                            hint: { text: t("estimate_flow.#{i18n_key}.percentage_owned.input_hint") }
+  = render "shared/percentage_input_with_hint",
+           form:,
+           field: :percentage_owned,
+           width: 3,
+           label_text: t("estimate_flow.#{i18n_key}.percentage_owned.input"),
+           size: "m",
+           hint_text: t("estimate_flow.#{i18n_key}.percentage_owned.input_hint")
 
   - if show_joint_ownership
     = form.govuk_radio_buttons_fieldset :joint_ownership,
@@ -32,11 +33,12 @@
             legend: { text: t("estimate_flow.#{i18n_key}.joint_ownership.legend") } do
       = form.govuk_radio_button :joint_ownership, true,
               label: { text: t("generic.yes_choice") } do
-        = form.govuk_text_field :joint_percentage_owned,
+        = render "shared/percentage_input",
+                form:,
+                field: :joint_percentage_owned,
                 width: 3,
-                suffix_text: "%",
-                value: integer_field_value(form, :joint_percentage_owned),
-                label: { text: t("estimate_flow.#{i18n_key}.joint_percentage_owned.input"), size: "m" }
+                label_text: t("estimate_flow.#{i18n_key}.joint_percentage_owned.input"),
+                size: "m"
 
       = form.govuk_radio_button :joint_ownership, false,
               label: { text: t("generic.no_choice") }

--- a/app/views/estimate_flow/forms/_property_entry.html.slim
+++ b/app/views/estimate_flow/forms/_property_entry.html.slim
@@ -19,7 +19,7 @@
              label_text: t("estimate_flow.#{i18n_key}.mortgage.input"),
              hint_text: t("estimate_flow.#{i18n_key}.mortgage.input_hint")
 
-  = render "shared/percentage_input_with_hint",
+  = render "shared/percentage_input",
            form:,
            field: :percentage_owned,
            width: 3,

--- a/app/views/shared/_percentage_input.html.slim
+++ b/app/views/shared/_percentage_input.html.slim
@@ -1,0 +1,6 @@
+- size ||= nil
+= form.govuk_text_field field,
+                        width:,
+                        label: { text: label_text, size: },
+                        suffix_text: "%",
+                        inputmode: "numeric"

--- a/app/views/shared/_percentage_input.html.slim
+++ b/app/views/shared/_percentage_input.html.slim
@@ -1,6 +1,8 @@
+- hint_text ||= nil
 - size ||= nil
 = form.govuk_text_field field,
                         width:,
+                        hint: { text: hint_text },
                         label: { text: label_text, size: },
                         suffix_text: "%",
                         inputmode: "numeric"

--- a/app/views/shared/_percentage_input_with_hint.html.slim
+++ b/app/views/shared/_percentage_input_with_hint.html.slim
@@ -1,0 +1,7 @@
+- size ||= nil
+= form.govuk_text_field field,
+                        width:,
+                        hint: { text: hint_text },
+                        label: { text: label_text, size: },
+                        suffix_text: "%",
+                        inputmode: "numeric"

--- a/app/views/shared/_percentage_input_with_hint.html.slim
+++ b/app/views/shared/_percentage_input_with_hint.html.slim
@@ -1,7 +1,0 @@
-- size ||= nil
-= form.govuk_text_field field,
-                        width:,
-                        hint: { text: hint_text },
-                        label: { text: label_text, size: },
-                        suffix_text: "%",
-                        inputmode: "numeric"


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-888)

## What changed and why

When using CCQ on a ‘mobile device’ screen, and you are asked to input percentage share of an housing asset. The user is now shown a numerical screen keyboard (without decimal) not a qwerty screen keyboard. 

## Guidance to review

Please check that this works on both client and partner flows. 

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
