### PR TITLE
EL-893: Fix js back buttons

### DIFF
--- a/app/controllers/estimates_controller.rb
+++ b/app/controllers/estimates_controller.rb
@@ -1,5 +1,5 @@
 class EstimatesController < ApplicationController
-  before_action :load_check, only: %i[show print download]
+  before_action :load_check, only: %i[check_answers show print download]
 
   def new
     redirect_to estimate_build_estimate_path SecureRandom.uuid, Steps::Helper.first_step

--- a/app/lib/steps/helper.rb
+++ b/app/lib/steps/helper.rb
@@ -30,6 +30,10 @@ module Steps
         steps_list_for({}).first
       end
 
+      def last_step(session_data)
+        steps_list_for(session_data || {}).last
+      end
+
     private
 
       def steps_list_for(session_data)

--- a/app/views/estimates/check_answers.html.slim
+++ b/app/views/estimates/check_answers.html.slim
@@ -1,7 +1,9 @@
 - content_for :page_title
   = t(".heading")
 - content_for :back
-  = back_link(:check_answers, @check, true)
+  = link_to t("generic.back"),
+            estimate_build_estimate_path(params[:id], Steps::Helper.last_step(@check&.session_data)),
+            class: "govuk-back-link"
 
 .govuk-grid-column-two-thirds
   = render "shared/heading", header_text: t(".heading")

--- a/app/views/estimates/show.html.slim
+++ b/app/views/estimates/show.html.slim
@@ -5,7 +5,7 @@
     = t(".likely_to_qualify")
 
 - content_for :back do
-  = link_to t("generic.back"), "javascript:history.back()", class: "govuk-back-link"
+  = link_to t("generic.back"), check_answers_estimate_path(params[:id]), class: "govuk-back-link"
 
 .govuk-panel.panel-blue.govuk-panel--confirmation class="govuk-!-text-align-left govuk-!-margin-bottom-9"
   .govuk-panel__body


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-893)

## What changed and why

The 'back' button on the results page now always leads back to the check answers page.
The one of the check answers page now always leads back to the last step in the flow.

## Guidance to review

<!-- anything useful to let the reviewer know? -->

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
