### PR TITLE
Silence 3rd party deprecation warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,6 @@
   },
   "scripts": {
     "build": "esbuild app/javascript/*.* --bundle --sourcemap --outdir=app/assets/builds --public-path=assets",
-    "build:css": "sass ./app/assets/stylesheets/application.sass.scss:./app/assets/builds/application.css --no-source-map --load-path=node_modules"
+    "build:css": "sass ./app/assets/stylesheets/application.sass.scss:./app/assets/builds/application.css --no-source-map --load-path=node_modules --quiet-deps"
   }
 }


### PR DESCRIPTION
Every time we (or CI) builds our SCSS we get a slew of deprecation warnings because `govuk-frontend` uses a deprecated approach to doing division. This has been a known issue for 2 years - https://github.com/alphagov/govuk-frontend/issues/2238 - and won't be going away any time soon, as using deprecated functionality is needed to support various Sass libraries. The [recommended approach](https://github.com/alphagov/govuk-frontend/issues/2238#issuecomment-852191702) is to simply suppress 3rd party deprecation warnings, which is what this PR does.