### PR TITLE
EL-904: Use HTML-safe translations

### DIFF
--- a/app/views/accessibilities/_list.html.slim
+++ b/app/views/accessibilities/_list.html.slim
@@ -1,4 +1,3 @@
-- paragraphs.each do |p|
-  h2.govuk-heading-m = p.fetch(:heading)
-  - p.fetch(:text).each do |text|
-    p.govuk-body == text
+h2.govuk-heading-m = t("#{key}.heading")
+- t("#{key}.text_html").each do |text|
+  p.govuk-body = text

--- a/app/views/accessibilities/show.html.slim
+++ b/app/views/accessibilities/show.html.slim
@@ -10,7 +10,7 @@
       li = bullet
   p.govuk-body = t(".p1_extra_text")
   p.govuk-body = t(".p1_extra_html")
-  = render "list", paragraphs: t(".paragraphs")
+  = render "list", key: "accessibilities.show.headed_paragraph"
 
   h2.govuk-heading-m = t(".p12_heading")
   p.govuk-body = t(".p12_html")
@@ -21,9 +21,9 @@
   h2.govuk-heading-m = t(".p14_heading")
   p.govuk-body = t(".p14_html")
 
-  = render "list", paragraphs: t(".paragraphs2")
+  = render "list", key: "accessibilities.show.headed_paragraph2"
 
   h3.govuk-heading-s = t(".p31_heading")
   p.govuk-body = t(".p31_html")
 
-  = render "list", paragraphs: t(".paragraphs4")
+  = render "list", key: "accessibilities.show.headed_paragraph4"

--- a/app/views/cookies/show.html.slim
+++ b/app/views/cookies/show.html.slim
@@ -2,11 +2,11 @@
   = t(".title")
 = render "shared/heading", header_text: t(".title")
 p.govuk-body
-  == t(".paragraph_1", service_name: link_to(t("service.name"), root_path, class: "govuk-link"))
+  = t(".paragraph_1_html", service_name: link_to(t("service.name"), root_path, class: "govuk-link"))
 p.govuk-body
   = t(".paragraph_2", service_name: t("service.name"))
 p.govuk-body
-  == t(".paragraph_3", how_to_manage: link_to(t(".how_to_manage"),
+  = t(".paragraph_3_html", how_to_manage: link_to(t(".how_to_manage"),
                                       "https://ico.org.uk/for-the-public/online/cookies",
                                       class: "govuk-link"))
 h2.govuk-heading-l class="govuk-!-margin-top-6"

--- a/app/views/estimate_flow/matter_type.html.slim
+++ b/app/views/estimate_flow/matter_type.html.slim
@@ -12,24 +12,24 @@
     - if @check.controlled?
       = govuk_details(summary_text: t(".immigration_header_controlled"))
         p.govuk-body = t(".immigration_controlled_paragraph_one")
-        p.govuk-body == t(".immigration_controlled_paragraph_two_html")
+        p.govuk-body = t(".immigration_controlled_paragraph_two_html")
 
       = govuk_details(summary_text: t(".asylum_header_controlled"))
         p.govuk-body = t(".asylum_controlled_paragraph_one")
         ul.govuk-list.govuk-list--bullet
           - t(".asylum_controlled_bullets").each do |bullet|
             li = bullet
-        p.govuk-body == t(".asylum_controlled_paragraph_two_html")
+        p.govuk-body = t(".asylum_controlled_paragraph_two_html")
     - else
       p.govuk-body = t(".immigration_and_asylum_certificated_paragraph")
 
       = govuk_details(summary_text: t(".immigration_header_certificated"))
         p.govuk-body = t(".immigration_certificated_paragraph_one")
-        p.govuk-body == t(".immigration_certificated_paragraph_two_html")
+        p.govuk-body = t(".immigration_certificated_paragraph_two_html")
 
       = govuk_details(summary_text: t(".asylum_header_certificated"))
         p.govuk-body = t(".asylum_certificated_paragraph_one")
-        p.govuk-body == t(".asylum_certificated_paragraph_two_html")
+        p.govuk-body = t(".asylum_certificated_paragraph_two_html")
 
       h2.govuk-heading-s = t(".domestic_abuse_header")
       p.govuk-body = t(".domestic_abuse_paragraph")

--- a/app/views/estimates/_controlled_work_next_steps.html.slim
+++ b/app/views/estimates/_controlled_work_next_steps.html.slim
@@ -7,4 +7,4 @@ ol.govuk-list.govuk-list--number
     li = bullet
 
 h3.govuk-heading-s = t("estimates.show.controlled_cw_next_steps.manual_header")
-p.govuk-body == t("estimates.show.controlled_cw_next_steps.manual_instruction")
+p.govuk-body = t("estimates.show.controlled_cw_next_steps.manual_instruction_html")

--- a/app/views/estimates/_limits_table.html.slim
+++ b/app/views/estimates/_limits_table.html.slim
@@ -4,8 +4,8 @@ p.govuk-body = t(".outgoings_explanation")
 
 - lower_limits = @model.level_of_help == "certificated" && !@check.upper_tribunal?
 - upper_limit_could_be_waived = @model.level_of_help == "certificated" && !@check.upper_tribunal?
-- t(".list").each do |reason|
-    p.govuk-body == reason
+- t(".list_html").each do |reason|
+    p.govuk-body = reason
 - if lower_limits
   p.govuk-body = t(".certificated_last_item")
 

--- a/app/views/estimates/print.html.slim
+++ b/app/views/estimates/print.html.slim
@@ -37,7 +37,7 @@
       = render "controlled_work_next_steps"
     - else
       p.govuk-body = t("estimates.show.controlled_next_steps_paragraph_1")
-      p.govuk-body == t("estimates.show.controlled_next_steps_paragraph_2")
+      p.govuk-body = t("estimates.show.controlled_next_steps_paragraph_2_html")
 
     h2.govuk-heading-m = t("estimates.show.evidence_needed")
     p.govuk-body = t("estimates.show.evidence_needed_explainer")

--- a/app/views/estimates/show.html.slim
+++ b/app/views/estimates/show.html.slim
@@ -27,7 +27,7 @@
     = render "controlled_work_next_steps"
   - else
     p.govuk-body = t(".controlled_next_steps_paragraph_1")
-    p.govuk-body == t(".controlled_next_steps_paragraph_2")
+    p.govuk-body = t(".controlled_next_steps_paragraph_2_html")
 
   = govuk_details(summary_text: t(".evidence_needed")) do
     = render "evidence"

--- a/app/views/layouts/_cookie_banner.html.slim
+++ b/app/views/layouts/_cookie_banner.html.slim
@@ -25,7 +25,7 @@
           .govuk-grid-column-two-thirds
             .govuk-cookie-banner__content
               p.govuk-body
-                == t("cookie_banner.accepted", change_link: link_to(t("cookie_banner.change"), cookies_path, class: "govuk-link"))
+                = t("cookie_banner.accepted_html", change_link: link_to(t("cookie_banner.change"), cookies_path, class: "govuk-link"))
 
         .govuk-button-group
           a href=request.env["PATH_INFO"] role="button" draggable="false" class="govuk-button" data-module="govuk-button"
@@ -37,7 +37,7 @@
           .govuk-grid-column-two-thirds
             .govuk-cookie-banner__content
               p.govuk-body
-                == t("cookie_banner.rejected", change_link: link_to(t("cookie_banner.change"), cookies_path, class: "govuk-link"))
+                = t("cookie_banner.rejected_html", change_link: link_to(t("cookie_banner.change"), cookies_path, class: "govuk-link"))
 
         .govuk-button-group
           a href=request.env["PATH_INFO"] role="button" draggable="false" class="govuk-button" data-module="govuk-button"

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -1,7 +1,10 @@
 html dir="ltr" lang="en-GB" class="govuk-template"
   head
     = render "layouts/analytics_head"
-    title == [yield(:page_title).presence, t("service.name"), "GOV.UK"].compact.join(" | ")
+    title
+      = yield(:page_title)
+      = " | " if content_for?(:page_title)
+      = t("service.name_for_page_title")
 
     = csrf_meta_tags
     = csp_meta_tag

--- a/app/views/layouts/print_application.html.slim
+++ b/app/views/layouts/print_application.html.slim
@@ -1,7 +1,10 @@
 html dir="ltr" lang="en-GB" class="govuk-template"
   head
     = render "layouts/analytics_head"
-    title == [yield(:page_title).presence, t("service.name"), "GOV.UK"].compact.join(" | ")
+    title
+      = yield(:page_title)
+      = " | " if content_for?(:page_title)
+      = t("service.name_for_page_title")
 
     = csrf_meta_tags
     = csp_meta_tag

--- a/app/views/shared/_disregarded_benefits_details.html.slim
+++ b/app/views/shared/_disregarded_benefits_details.html.slim
@@ -5,4 +5,4 @@
     b = t("generic.disregarded_benefits.#{benefit_type}.text")
     p.govuk-body
       - t("generic.disregarded_benefits.#{benefit_type}.list").each do
-        div == _1
+        div = _1

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -441,6 +441,7 @@ en:
               blank: Select which form you need
   service:
     name: Check if your client qualifies for legal aid
+    name_for_page_title: Check if your client qualifies for legal aid | GOV.UK
     email: eligibility@justice.gov.uk
     user_survey_link: https://eu.surveymonkey.com/r/ccq1
     beta: Beta
@@ -1554,7 +1555,7 @@ en:
       certificated_how_calculated: How we calculated whether your client is likely to be financially eligible for civil certificated legal aid work
       controlled_how_calculated: How we calculated whether your client is likely to be financially eligible for civil controlled legal aid work
       controlled_next_steps_paragraph_1: You will need to complete the relevant controlled work form and keep for your records, along with any evidence provided by your client. Your client’s file may be audited and assessed by the LAA at a later date.
-      controlled_next_steps_paragraph_2: "You can find the forms at: <a href='https://www.gov.uk/government/collections/controlled-work-application-forms' target='_blank' rel='noreferrer noopener'>Controlled work application forms</a>."
+      controlled_next_steps_paragraph_2_html: "You can find the forms at: <a href='https://www.gov.uk/government/collections/controlled-work-application-forms' target='_blank' rel='noreferrer noopener'>Controlled work application forms</a>."
       controlled_types_of_evidence:
         - bank statements covering the most recent month
         - evidence of any benefits or financial support your client received from the government, local authorities or third parties dated in the last 6 months
@@ -1767,7 +1768,7 @@ en:
           - Get your client to sign the form.
           - Keep the form, with any evidence provided by your client, for your records.
         manual_header:  Complete a controlled work form yourself
-        manual_instruction: Download a <a href='https://www.gov.uk/government/collections/controlled-work-application-forms' target='_blank' rel='noreferrer noopener'>controlled work application form</a>. Some of these can be filled in on a computer.
+        manual_instruction_html: Download a <a href='https://www.gov.uk/government/collections/controlled-work-application-forms' target='_blank' rel='noreferrer noopener'>controlled work application form</a>. Some of these can be filled in on a computer.
       ineligible_explanation:
         text: Your %{subject} %{value_type} exceeds the upper limit. This means %{outcome} not qualify for legal aid.
         subject_no_partner: client’s
@@ -1784,7 +1785,7 @@ en:
       calculation_information: We’ve used the information you provided to compare your client’s income and outgoings. This allows us to calculate their monthly disposable income.
       limits_heading: Limits
       outgoings_explanation: "For some outgoings, you may see figures that differ from what you entered. This is because some outgoing amounts are capped or disregarded in certain situations. For example:"
-      list:
+      list_html:
         - Childcare costs will display as £0 if your client is not employed or a student (<a href="https://www.legislation.gov.uk/uksi/2013/480/regulation/27" target='_blank' rel='noreferrer noopener'>Regulation 27 of the Civil Legal Aid (Financial Resources and Payment for Services) Regulations 2013 (opens in new tab)</a>).
         - Housing costs are capped at £545 per month if your client is single and does not have any dependants (<a href="https://www.legislation.gov.uk/uksi/2013/480/regulation/28" target='_blank' rel='noreferrer noopener'>Regulation 28(7) of the Civil Legal Aid (Financial Resources and Payment for Services) Regulations 2013 (opens in new tab)</a>).
         - If your client’s gross income is above the applicable upper gross income limit, they will not qualify for legal aid. If this occurs, our service will not perform disposable income or disposable capital calculations. Any figures you entered in the outgoings or capital sections may either display as £0, or not at all.
@@ -1881,15 +1882,15 @@ en:
     reject: Reject additional cookies
     view: View cookies
     change: change your cookie settings
-    accepted: You’ve accepted additional cookies. You can %{change_link} at any time.
-    rejected: You’ve rejected additional cookies. You can %{change_link} at any time.
+    accepted_html: You’ve accepted additional cookies. You can %{change_link} at any time.
+    rejected_html: You’ve rejected additional cookies. You can %{change_link} at any time.
     hide: Hide cookie message
   cookies:
     show:
       title: Cookies
-      paragraph_1: "%{service_name} puts small files (known as ‘cookies’) on your computer."
+      paragraph_1_html: "%{service_name} puts small files (known as ‘cookies’) on your computer."
       paragraph_2: These cookies are used across the %{service_name} website.
-      paragraph_3: Find out %{how_to_manage} from the Information Commissioner's Office.
+      paragraph_3_html: Find out %{how_to_manage} from the Information Commissioner's Office.
       how_to_manage: how to manage cookies
       essential_cookies: Essential cookies (strictly necessary)
       essential_cookie_explainer: We use an essential cookie to remember when you accept or reject cookies on our website, and another to remember your answers as you complete the eligibility form.
@@ -2031,10 +2032,10 @@ en:
         - listen to most of the website using a screen reader (including the most recent versions of JAWS, NVDA and VoiceOver)
       p1_extra_text: We’ve also made the website text as simple as possible to understand.
       p1_extra_html: "<a href='https://mcmw.abilitynet.org.uk/'>AbilityNet</a> has advice on making your device easier to use if you have a disability."
-      paragraphs:
-        - heading: How accessible this website is
-          text:
-            - "This website is fully compliant with levels A, AA and AAA of the Web Content Accessibility Guidelines – WCAG 2.1."
+      headed_paragraph:
+        heading: How accessible this website is
+        text_html:
+          - "This website is fully compliant with levels A, AA and AAA of the Web Content Accessibility Guidelines – WCAG 2.1."
       p12_heading: Reporting accessibility problems with this website
       p12_html: "We’re always looking to improve the accessibility of this website. If you find any problems not listed on this page or think we’re not meeting accessibility requirements, contact us by email at eligibility@justice.gov.uk."
       p13_heading: Enforcement procedure
@@ -2043,17 +2044,17 @@ en:
       p13_html: If you’re not happy with how we respond to your complaint, <a rel="external" href="https://www.equalityadvisoryservice.com/">contact the Equality Advisory and Support Service (<abbr title="Equality Advisory and Support Service">EASS</abbr>)</a>.
       p14_heading: Contacting us
       p14_html: "Contact us by email at eligibility@justice.gov.uk."
-      paragraphs2:
-        - heading: Technical information about this website’s accessibility
-          text:
-            - "The Legal Aid Agency is committed to making its websites accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018."
+      headed_paragraph2:
+        heading: Technical information about this website’s accessibility
+        text_html:
+          - "The Legal Aid Agency is committed to making its websites accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018."
       p31_heading: Compliance status
       p31_html: This website is fully compliant with the <a href="https://www.w3.org/TR/WCAG21/">Web Content Accessibility Guidelines version 2.1</a> AA Standard.
-      paragraphs4:
-        - heading: Preparation of this accessibility statement
-          text:
-            - This statement was prepared on 12 December 2022. It was last reviewed on 10 January 2023.
-            - This website was last tested on 4 January 2023. The test was carried out by <a href="https://digitalaccessibilitycentre.org">Digital Accessibility Centre (DAC)</a>.
+      headed_paragraph4:
+        heading: Preparation of this accessibility statement
+        text_html:
+          - This statement was prepared on 12 December 2022. It was last reviewed on 10 January 2023.
+          - This website was last tested on 4 January 2023. The test was carried out by <a href="https://digitalaccessibilitycentre.org">Digital Accessibility Centre (DAC)</a>.
   cost_of_living_details:
     header: Government Cost of Living Payments
     text: Government Cost of Living Payments are disregarded from the financial eligibility calculation, for example


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-904)

## What changed and why

`== t(` is bad, because the output of `t` can't always be trusted if it includes interpolated values. Using `t`'s built-in HTML-safe-marking system is better, so we now do that (and, in general, don't use `==` to render _any_ text in views any more.

## Guidance to review

<!-- anything useful to let the reviewer know? -->

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
