### PR TITLE
Utility to detect stale i18n keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,13 @@ It knows how answers to certain questions affect the relevance of certain other 
 **Check** provides access to all _relevant_ data for a check. For any attribute it uses Steps::Helper and Flow::Handler to determine whether,
 given the other answers supplied, the attribute is relevant. If not, when asked for that attribute it will return `nil`. Otherwise it will return that attribute.
 
+## I18n
+
+We keep all user-facing content strings in locale files. In particular, `config/locales/en.yml` contains nearly every piece of text on the site.
+ We have a utility to help identify obsolete content built into our test suite.
+You can run `CHECK_UNUSED_KEYS=true bundle exec rspec` and it will print out, at the end of the test run, all keys found in `en.yml` that don't get looked up by the test suite.
+Using this periodically can help remove stale content from that file.
+
 ## Deploying to UAT/Staging/Production
 
 The service uses `helm` to deploy to Cloud Platform Environments via CircleCI. This can be installed using:

--- a/app/helpers/assets_helper.rb
+++ b/app/helpers/assets_helper.rb
@@ -8,7 +8,7 @@ module AssetsHelper
               first_links
             else
               first_links.merge({
-                t("estimate_flow.assets.disregarded_capital_guidance.text") => t("estimate_flow.assets.disregarded_capital_guidance.certificated.link"),
+                t("estimate_flow.assets.disregarded_capital_guidance.text") => t("estimate_flow.assets.disregarded_capital_guidance.link"),
               })
             end
 

--- a/app/views/estimate_flow/household_flow/_assets.html.slim
+++ b/app/views/estimate_flow/household_flow/_assets.html.slim
@@ -7,7 +7,7 @@
   = render "estimate_flow/household_flow/forms/assets",
            i18n_key: "assets",
            show_smod_content: @check.smod_applicable?,
-           hints: ([t("estimate_flow.assets.partner_hint"), t("estimate_flow.assets.partner_second_hint")] if @check.partner)
+           hints: [t("estimate_flow.assets.hint"), (t("estimate_flow.assets.partner_second_hint") if @check.partner)].compact
 
 = render "shared/question_sidebar",
         level_of_help: @check.level_of_help,

--- a/app/views/estimate_flow/non_household_flow/_assets.html.slim
+++ b/app/views/estimate_flow/non_household_flow/_assets.html.slim
@@ -7,7 +7,7 @@
   = render "estimate_flow/non_household_flow/forms/assets",
            i18n_key: "assets",
            show_smod_content: @check.smod_applicable?,
-           hints: ([t("estimate_flow.assets.partner_hint"), t("estimate_flow.assets.partner_second_hint")] if @check.partner)
+           hints: [t("estimate_flow.assets.hint"), (t("estimate_flow.assets.partner_second_hint") if @check.partner)].compact
 
 = render "shared/question_sidebar",
         level_of_help: @check.level_of_help,

--- a/app/views/estimates/_capital_table.html.slim
+++ b/app/views/estimates/_capital_table.html.slim
@@ -85,10 +85,10 @@
           - row.with_cell(classes: %w[no-bottom-border], text: "")
         - @model.pensioner_disregard_rows.each do |type, amount|
           - body.with_row do |row|
-            - row.with_cell(header: true, text: t("estimates.show.pensioner_disregard_types.#{type}.text"))
+            - row.with_cell(header: true, text: t("estimates.show.pensioner_disregard_types.#{type}"))
             - row.with_cell(numeric: true, text: amount)
         - body.with_row(classes: %w[solid-top-border]) do |row|
-          - row.with_cell(header: true, text: t("estimates.show.pensioner_disregard_types.assessed_capital.text"))
+          - row.with_cell(header: true, text: t("estimates.show.pensioner_disregard_types.assessed_capital"))
           - row.with_cell(numeric: true, header: true, text: @model.total_assessed_capital)
 
 h2 class="govuk-heading-#{caption_size}" = t("estimates.show.total")

--- a/app/views/estimates/_limits_table.html.slim
+++ b/app/views/estimates/_limits_table.html.slim
@@ -12,7 +12,7 @@ p.govuk-body = t(".outgoings_explanation")
 - if lower_limits
   p.govuk-body = t(".upper_and_lower_monetary_limits")
 - else
-  p.govuk-body = t(".upper_and_lower_monetary_limits")
+  p.govuk-body = t(".upper_monetary_limits")
 
 table class="govuk-table"
   caption class="govuk-table__caption govuk-table__caption--m" = t(".gross_income_caption")

--- a/app/views/privacies/show.html.slim
+++ b/app/views/privacies/show.html.slim
@@ -30,7 +30,7 @@
     - t(".why_we_do_bullets").each do |bullet|
       li = bullet
 
-  h2.govuk-heading-m = t(".why_heading")
+  h2.govuk-heading-m = t(".legal_section")
   - t(".legal_basis_section").each do |paragraph|
     p.govuk-body = paragraph
 

--- a/app/views/shared/_disregarded_benefits_details.html.slim
+++ b/app/views/shared/_disregarded_benefits_details.html.slim
@@ -1,5 +1,4 @@
-- key = "text_with_col"
-= govuk_details(summary_text: t("generic.disregarded_benefits.#{key}")) do
+= govuk_details(summary_text: t("generic.disregarded_benefits.text")) do
   - types = (%i[cost_of_living disregarded] + %i[disability low_income other])
   - types.each do |benefit_type|
     b = t("generic.disregarded_benefits.#{benefit_type}.text")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,10 +6,6 @@ en:
           attributes:
             level_of_help:
               blank: Select the level of help your client needs
-        tribunal_form:
-          attributes:
-            upper_tribunal:
-              inclusion: Select yes if the case relates to proceedings in the Immigration and Asylum chamber of either the First-tier or Upper Tribunal
         asylum_support_form:
           attributes:
             asylum_support:
@@ -462,7 +458,6 @@ en:
   service:
     name: Check if your client qualifies for legal aid
     name_for_page_title: Check if your client qualifies for legal aid | GOV.UK
-    email: eligibility@justice.gov.uk
     user_survey_link: https://eu.surveymonkey.com/r/ccq1
     beta: Beta
     beta_message_html: This is a new service - your <a href="%{user_survey_link}" target="_blank">feedback</a> will help us improve it
@@ -477,10 +472,7 @@ en:
     error_summary_title: There is a problem
     error_prefix: "Error:"
     save_and_continue: Save and continue
-    submit: Submit
-    check_box_divider: or
     change: Change
-    date: Date
     level_of_help:
       text: Level of help
       certificated: Civil certificated or licensed legal work
@@ -512,8 +504,7 @@ en:
       controlled:
         link: "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/983065/Lord_Chancellor_s_guidance_on_determining_controlled_work_and_family_mediation.pdf#page=20"
     disregarded_benefits:
-      text: Disregarded benefits
-      text_with_col: Government Cost of Living Payments and disregarded benefits
+      text: Government Cost of Living Payments and disregarded benefits
       cost_of_living:
         text: Government Cost of Living Payments
         list:
@@ -604,7 +595,6 @@ en:
       mental_health_guidance:
         text: Means assessment section of Mental Health guidance
         link: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/1143984/Mental_Health_Guidance_-_Contract_management_-_GOV.UK_2023.pdf
-      certificated_hint: This includes full representation and family help (higher)
     asylum_support:
       question: Does your client get Asylum Support?
       help_text_1: This means Asylum Support as defined in Section 4 or Section 95 of the Immigration and Asylum Act 1999.
@@ -652,13 +642,6 @@ en:
         - legal representation for an asylum matter in the Immigration and Asylum Chamber of the First-tier Tribunal
       asylum_controlled_paragraph_two_html: Guidance for this is in paragraphs 24 to 30, 32(1) and 32A(1) of Part 1 of Schedule 1 to the <a href='https://www.legislation.gov.uk/ukpga/2012/10/schedule/1' target='_blank' rel='noreferrer noopener'>Legal Aid, Sentencing and Punishment of Offenders Act 2012</a> (LASPO).
       select_a_matter_type: Select a matter type
-    partner:
-      partner_guidance:
-        text: "Guidance on partners"
-        link: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/1045682/Lord_Chancellor_s_guidance_on.pdf#page=17
-      caption: About your client
-      legend: Does your client have a partner?
-      hint: This is a spouse, someone with whom they are in a civil relationship, a cohabiter or someone they share their finances with. They cannot be the opponent in any legal proceedings.
     applicant:
       passporting_guidance:
         text: Guidance on passporting
@@ -676,7 +659,6 @@ en:
       caption: About your client
       partner:
         rb_hint: You will be asked questions about the partner after you have answered questions about your client
-        caption: About your client
         legend: Does your client have a partner?
         hint_text: "A partner is someone your client is:"
         hint_list:
@@ -689,10 +671,6 @@ en:
             - is separated from the client in a way that is likely to be permanent
             - is an opponent in the case
             - has a contrary interest in the case - this means they want a different outcome to your client
-        hint: This is a spouse, someone with whom they are in a civil relationship, a cohabiter or someone they share their finances with. They cannot be the opponent in any legal proceedings.
-      domestic_abuse_guidance:
-        text: Guidance on domestic abuse or violence
-        link: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/1045682/Lord_Chancellor_s_guidance_on.pdf#page=13
       over_60:
         legend: Is your client aged 60 or over?
         hint: Clients aged 60 or over may have some of their capital excluded from a financial eligibility assessment.
@@ -813,7 +791,6 @@ en:
       adult_dependants:
         legend: Does the partner have any adult dependants?
         label: How many?
-        no_partner_hint: An adult dependant is any adult relative who lives with your client and depends on them for financial support. Do not include anyone who owns any property, vehicles or other assets valued at over £8,000 in total.
         hints:
           - An adult dependant is any adult relative who lives with the partner and depends on them for financial support.
           - "Do not include:"
@@ -926,14 +903,11 @@ en:
         every_two_weeks: Every 2 weeks
         every_four_weeks: Every 4 weeks
         monthly: Every month
-      added_heading: You have added %{count} %{benefit}
-      benefit: benefit
     benefit_details:
       caption: Your client's finances
       heading: Add benefit details
       hint: Add details of any benefits your client receives. Do not include Housing Benefit or any other disregarded benefits.
       benefit: Benefit
-      suggestions: Suggestion
       benefit_type: Benefit name
       benefit_type_hint: Enter the name of a benefit, or select one from the suggestions that appear when you start to enter the name.
       enter_amount: Enter benefit amount
@@ -943,7 +917,6 @@ en:
       caption: The partner's finances
       legend: Does the partner get any benefits?
       legend_non_household: Does the partner get any other benefits?
-      benefit: benefit
     partner_benefit_details:
       caption: The partner's finances
       heading: Add benefit details
@@ -1085,8 +1058,6 @@ en:
           - Enter 0 if this does not apply
       enter_amount: Enter amount
       enter_frequency: Select frequency
-      guidance_on_outgoings: Guidance on outgoings (need link)
-      link_to_guidance_on_outgoings: "#TODO: To be defined"
     property:
       non_household_flow:
         caption: Your client's finances
@@ -1097,7 +1068,6 @@ en:
         outright: Yes, owned outright
         with_mortgage: Yes, with a mortgage or loan
         none: "No"
-        legend: Does your client and/or their partner own the home they live in?
       properties_guidance:
         text: Guidance on properties
         certificated:
@@ -1131,14 +1101,10 @@ en:
       vehicle_owned:
         legend: Does the partner own a vehicle?
         hint: "This includes cars, vans and motorcycles. Do not add any vehicle you've listed as the client’s vehicle."
-      guidance:
-        text: Guidance on vehicles
-        link: "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/1045682/Lord_Chancellor_s_guidance_on.pdf#page=55"
     assets:
       caption: Your client's finances
       legend: Client assets
       hint: Enter 0 for any that do not apply
-      partner_hint: Enter 0 for any that do not apply.
       partner_second_hint: If any of these assets are owned by both the client and partner, enter the full value here. Do not enter them again on the partner questions that follow.
       non_household_flow:
         property:
@@ -1196,10 +1162,7 @@ en:
           link: "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/1045682/Lord_Chancellor_s_guidance_on.pdf#page=47"
       disregarded_capital_guidance:
         text: Guidance on disregarded capital
-        certificated:
-          link: "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/1045682/Lord_Chancellor_s_guidance_on.pdf#page=70"
-        controlled:
-          link: "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/983065/Lord_Chancellor_s_guidance_on_determining_controlled_work_and_family_mediation.pdf#page=20"
+        link: "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/1045682/Lord_Chancellor_s_guidance_on.pdf#page=70"
       other_property_guidance:
         text: Guidance on properties owned that are not the 'main house'
         certificated:
@@ -1258,9 +1221,6 @@ en:
           - For example, any vehicle that is not in regular use, jewellery, art, antiques or caravan or similar.
           - Enter 0 if this does not apply.
         input: Total of all valuable items
-      guidance:
-        text: Guidance on assets
-        link: "#"
     property_entry:
       heading: The home your client lives in
       hint: If you make an application for civil legal aid, the property's value may be excluded from the financial assessment if your client has left their former matrimonial home because of domestic abuse
@@ -1890,7 +1850,6 @@ en:
         dependants_allowance: A fixed allowance deducted for each dependant the partner has
         partner_allowance: ""
       capital_calculation: Capital calculation
-      client_capital: Client's capital
       client_capital_types:
         property:
           text: Assessed property value
@@ -1931,15 +1890,9 @@ en:
           hint: Equal to the assessed value of all assets marked as disputed and capped at £100,000
           alt_hint: Equal to the assessed value of all assets marked as disputed and capped at £100,000
       pensioner_disregard_types:
-        total_capital:
-          text: Total client and partner disposable capital
-          hint: ""
-        pensioner_capital_disregard:
-          text: Pensioner disregard
-          hint: ""
-        assessed_capital:
-          text: Total assessed disposable capital
-          hint: ""
+        total_capital: Total client and partner disposable capital
+        pensioner_capital_disregard: Pensioner disregard
+        assessed_capital: Total assessed disposable capital
       gross_monthly_income: Total monthly income
       gross_with_partner: Total client and partner monthly income
       gross_income_upper_threshold: Monthly income upper limit
@@ -1949,12 +1902,10 @@ en:
       disposable_income_hint: Total monthly income minus total monthly outgoings
       disposable_income_upper_threshold: Disposable monthly income upper limit
       client_assessed_capital: Disposable capital
-      partner_assessed_capital: Disposable capital
       start_another_check: Start another eligibility check
       continue_to_cw: Continue to CW forms
       print_page: Print this page
       save_as_pdf: Save this page as a PDF
-      total_capital: Total capital
       client_main_home: Home client lives in
       property_rows:
         value:
@@ -1980,7 +1931,6 @@ en:
           text: Assessed value
           partial_partner_hint: Partner’s %{percentage}% share of home equity
           partial_client_hint: Client’s %{percentage}% share of home equity
-      assessed_value: Amount included in calculation
       client_disposable_capital: Client's disposable capital
       partner_disposable_capital: Partner's disposable capital
       legacy_vehicles: Client's vehicle
@@ -1998,7 +1948,6 @@ en:
       partner_additional_property: Partner's additional property
       capital_upper_threshold: Disposable capital upper limit
       total: Total
-      capped_contributions: "Capital contributions will be limited to the likely costs of the case when the capital contribution figure stated exceeds that amount."
       pensioner_disregard: Pensioner disregard
       pensioner_disregard_caption: Applied to the total of the client and partner's disposable capital, and capped at £100,000.
       capital_header:

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,21 +1,12 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require "spec_helper"
-require "unused_i18n_key_checker"
 ENV["RAILS_ENV"] ||= "test"
 require_relative "../config/environment"
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 
-module I18nRegistry
-  def lookup(locale, key, scope = [], options = {})
-    UnusedI18nKeyChecker.log(key)
-    super
-  end
-end
-
-I18n::Backend::Simple.include I18nRegistry
-
 # Add additional requires below this line. Rails is not loaded until this point!
+require "unused_i18n_key_checker"
 require "rspec/rails"
 require "axe-rspec"
 require "pry-rescue/rspec" if Rails.env.development?

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -97,7 +97,19 @@ RSpec.configure do |config|
   end
 
   config.after(:suite) do
-    UnusedI18nKeyChecker.check_unused_keys(ignore_stems: ["activemodel.errors"])
+    UnusedI18nKeyChecker.check_unused_keys(
+      # These are parts of the translation file where we know the test suite doesn't cover all useable text
+      ignore: [
+        "activemodel.errors",
+        "estimates.check_answers.employment_fields.frequency_options",
+        "estimates.check_answers.partner_employment_fields.partner_frequency_options",
+        "estimates.show.controlled_",
+        "estimates.show.property_rows.main_home_disregard.text",
+        "estimates.show.property_rows.equity.partial_partner_hint",
+        "estimates.show.capital_header.partner.first_controlled",
+        "estimates.show.ineligible_explanation",
+      ],
+    )
   end
 
   config.include ActiveSupport::Testing::TimeHelpers

--- a/spec/unused_i18n_key_checker.rb
+++ b/spec/unused_i18n_key_checker.rb
@@ -6,18 +6,18 @@ class UnusedI18nKeyChecker
     @used_keys << key.to_s unless @used_keys.include?(key.to_s)
   end
 
-  def self.check_unused_keys(ignore_stems: [])
+  def self.check_unused_keys(ignore: [])
     return unless ENV["CHECK_UNUSED_KEYS"]
 
     mappings = YAML.load_file(Rails.root.join("config/locales/en.yml"))
     defined_keys = define_keys(mappings["en"])
     not_ignored_defined_keys = defined_keys.reject do |defined_key|
-      ignore_stems.any? { defined_key.starts_with?(_1) }
+      ignore.any? { defined_key.starts_with?(_1) }
     end
 
-    unused_keys = not_ignored_defined_keys - Arra(@used_keys)
+    unused_keys = not_ignored_defined_keys - Array(@used_keys)
 
-    puts "\nObsolete i18n keys detected:\n#{unused_keys.join("\n")}" if unused_keys.any?
+    raise "Obsolete i18n keys detected:\n#{unused_keys.join("\n")}" if unused_keys.any?
   end
 
   def self.define_keys(mappings, prefix = nil)

--- a/spec/unused_i18n_key_checker.rb
+++ b/spec/unused_i18n_key_checker.rb
@@ -1,5 +1,7 @@
 class UnusedI18nKeyChecker
   def self.log(key)
+    return unless ENV["CHECK_UNUSED_KEYS"]
+
     @used_keys ||= []
     @used_keys << key.to_s unless @used_keys.include?(key.to_s)
   end
@@ -13,7 +15,7 @@ class UnusedI18nKeyChecker
       ignore_stems.any? { defined_key.starts_with?(_1) }
     end
 
-    unused_keys = not_ignored_defined_keys - @used_keys
+    unused_keys = not_ignored_defined_keys - Arra(@used_keys)
 
     puts "\nObsolete i18n keys detected:\n#{unused_keys.join("\n")}" if unused_keys.any?
   end
@@ -33,3 +35,12 @@ class UnusedI18nKeyChecker
     keys
   end
 end
+
+module I18nRegistry
+  def lookup(locale, key, scope = [], options = {})
+    UnusedI18nKeyChecker.log(key)
+    super
+  end
+end
+
+I18n::Backend::Simple.include I18nRegistry

--- a/spec/unused_i18n_key_checker.rb
+++ b/spec/unused_i18n_key_checker.rb
@@ -1,0 +1,35 @@
+class UnusedI18nKeyChecker
+  def self.log(key)
+    @used_keys ||= []
+    @used_keys << key.to_s unless @used_keys.include?(key.to_s)
+  end
+
+  def self.check_unused_keys(ignore_stems: [])
+    return unless ENV["CHECK_UNUSED_KEYS"]
+
+    mappings = YAML.load_file(Rails.root.join("config/locales/en.yml"))
+    defined_keys = define_keys(mappings["en"])
+    not_ignored_defined_keys = defined_keys.reject do |defined_key|
+      ignore_stems.any? { defined_key.starts_with?(_1) }
+    end
+
+    unused_keys = not_ignored_defined_keys - @used_keys
+
+    puts "\nObsolete i18n keys detected:\n#{unused_keys.join("\n")}" if unused_keys.any?
+  end
+
+  def self.define_keys(mappings, prefix = nil)
+    keys = []
+    mappings.each do |k, v|
+      case v
+      when String, Array
+        keys << "#{prefix}#{k}"
+      when Hash
+        define_keys(v, "#{prefix}#{k}.").each do |key|
+          keys << key
+        end
+      end
+    end
+    keys
+  end
+end


### PR DESCRIPTION
Having poked around at our `en.yml` file for #675 I noticed that there are a few obsolete keys in there. ~I'll raise a ticket to clear them out, but in the meantime~ I've built a little utility to help us detect obsolete keys to make that task easier. Here's a sample of its output:

<img width="1189" alt="Screenshot 2023-05-18 at 10 48 11" src="https://github.com/ministryofjustice/laa-estimate-financial-eligibility-for-legal-aid/assets/113888736/2dca2bd3-07e3-4fcf-bd66-48ba6568a190">

Update: I have also now cleared out the obsolete keys, and fixed a couple of small bugs where we were wrongly _not_ using a key that we should have been.
