### PR TITLE
[EL-951] Fix typo on CIVMEANS7

### DIFF
--- a/app/lib/controlled_work_mappings/civ_means_7.yml
+++ b/app/lib/controlled_work_mappings/civ_means_7.yml
@@ -170,10 +170,10 @@
 # Savings (non-SMOD)
 - name: FillText110
   type: text
-  source: non_smod_client_savings #check this not sure if correct
+  source: non_smod_client_savings
 
 # Partner savings (non-SMOD)
-- name: FillText114ß
+- name: FillText114
   type: text
   source: partner_savings
 


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-951)

## What changed and why

Cheeky typo preventing the population of partner savings on CIVMEANS7 

Also removed a left over note in the code as seems it is now redundant. CIV MEANS 7 has sections for smod and non-smod so I think the use of `non_smod_client_savings` is correct.

## Guidance to review

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
