### PR TITLE
Remove old flags from specs

### DIFF
--- a/spec/flows/controlled_work_documents_spec.rb
+++ b/spec/flows/controlled_work_documents_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "CW Forms", :controlled_flag, :cw_forms_flag, type: :feature do
+RSpec.describe "CW Forms", :cw_forms_flag, type: :feature do
   it "lets me access the CW form screen after a controlled check" do
     allow(CfeService).to receive(:call).and_return build(:api_result, eligible: "eligible")
     start_assessment

--- a/spec/services/cfe/partner_payload_service_spec.rb
+++ b/spec/services/cfe/partner_payload_service_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Cfe::PartnerPayloadService, :partner_flag do
+RSpec.describe Cfe::PartnerPayloadService do
   describe ".call" do
     let(:arbitrary_fixed_time) { Time.zone.local(2022, 10, 24, 9, 0, 0) }
     let(:service) { described_class }


### PR DESCRIPTION
No ticket for this, it was easier to just remove the flags than write a jira ticket.
Removed flags that are no longer in use and the specs dont need them


## Guidance to review

<!-- anything useful to let the reviewer know? -->

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
