### PR TITLE
EL-962: mortgage payments screen showing for passported clients

### DIFF
--- a/app/lib/steps/property_section.rb
+++ b/app/lib/steps/property_section.rb
@@ -26,12 +26,14 @@ module Steps
       end
 
       def housing_costs_property_group(session_data)
+        return if Steps::Logic.passported?(session_data)
+
         steps = if Steps::Logic.owns_property_with_mortgage_or_loan?(session_data)
                   %i[mortgage_or_loan_payment]
-                elsif !Steps::Logic.owns_property_outright?(session_data) && !Steps::Logic.passported?(session_data)
+                elsif !Steps::Logic.owns_property_outright?(session_data)
                   %i[housing_costs]
                 end
-        Steps::Group.new(*steps)
+        Steps::Group.new(*steps) if steps
       end
 
       def additional_property_steps(session_data)

--- a/spec/flows/household_flow_spec.rb
+++ b/spec/flows/household_flow_spec.rb
@@ -57,7 +57,6 @@ RSpec.describe "Household section flow", type: :feature do
     fill_in_vehicles_details_screen
     fill_in_property_screen(choice: "Yes, with a mortgage or loan")
     fill_in_property_entry_screen
-    fill_in_mortgage_or_loan_payment_screen
     fill_in_additional_property_screen(choice: "Yes, owned outright")
     fill_in_additional_property_details_screen
     fill_in_partner_additional_property_screen(choice: "Yes, owned outright")
@@ -74,7 +73,6 @@ RSpec.describe "Household section flow", type: :feature do
     fill_in_vehicles_details_screen
     fill_in_property_screen(choice: "Yes, with a mortgage or loan")
     fill_in_property_entry_screen
-    fill_in_mortgage_or_loan_payment_screen
     fill_in_additional_property_screen(choice: "Yes, owned outright")
     fill_in_additional_property_details_screen
     confirm_screen("check_answers")


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-962)

## What changed and why

Prevent the mortgage payments screen for appearing for passported clients

## Guidance to review

If the client is passported, we don't care about mortgage costs as they only impact disposable income, which is ignored.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
