### PR TITLE
[EL-982] Fix change loop redirect bug

### DIFF
--- a/app/forms/applicant_form.rb
+++ b/app/forms/applicant_form.rb
@@ -24,4 +24,12 @@ class ApplicantForm
 
   attribute :passporting, :boolean
   validates :passporting, inclusion: { in: [true, false] }
+
+  def attributes_for_export_to_session
+    if FeatureFlags.enabled?(:self_employed)
+      attributes.except!("employment_status")
+    else
+      attributes
+    end
+  end
 end

--- a/spec/flows/check_answers_flow_spec.rb
+++ b/spec/flows/check_answers_flow_spec.rb
@@ -73,4 +73,17 @@ RSpec.describe "Check answers", type: :feature do
     fill_in_immigration_or_asylum_screen
     confirm_screen("check_answers")
   end
+
+  it "redirects correctly from the applicant form when self employed flag is switched on", :self_employed_flag do
+    start_assessment
+    fill_in_forms_until(:employment_status)
+    fill_in_employment_status_screen
+    fill_in_forms_until(:check_answers)
+    confirm_screen("check_answers")
+    within "#section-client_details-header" do
+      click_on "Change"
+    end
+    fill_in_applicant_screen(over_60: "Yes")
+    confirm_screen("check_answers")
+  end
 end


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-982)

## What changed and why

We introduced a bug when adding the new employment status form. Originally we set the `employment_status` attribute from the applicant form. This has now changed with the new implementation, but we were still setting `employment_status` from the applicant form. It was being set to nil and then redirecting to the employment status form as nil is invalid.

## Guidance to review

Straight forward - only thing was to check if I could write a better test for this. I've gone with a test of the flow in the `check_answers_flow_spec.rb`

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
