### PR TITLE
EL-968: Remove unused IAM access keys from ElastiCache

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,3 +222,5 @@ Secrets have been stored for each environment using `kubectl create secret`. The
 * feature-flags-password
 
 The current values for these are available as secure notes in 1Password for each environment, should they be lost from Kubernetes.
+
+Test.


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-968)

## What changed and why

This is to test UAT branches not affected on Circle CI with removal of IAM access keys on cloud platform. 

## Guidance to review

<!-- anything useful to let the reviewer know? -->

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
