### PR TITLE
EL-961 Derive feature flags from session data, then env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,11 @@ For "static" feature flags we set the flag values in env vars.
 To add a new feature flag, set a `"#{flag_name.upcase}_FEATURE_FLAG"` env var with value `"ENABLED"` in all environments where you want the flag enabled.
 Then add `flag_name` to the list of flags  in `app/lib/feature_flags.rb`.
 
-To use the feature flag in your code, just call `FeatureFlags.enabled?(:flag_name)`.
+When adding a `flag_name` to the list of static flags, you will need to decide if this is a `"global"` flag i.e. always taken from the env var and not the session, or a `"session"` flag i.e. taken from the `session_data` of the check. 
+
+We introduced this as a way of making our feature flags 'backwards compatible' - if a user check is underway during the switch-on of a flag, their user journey will not be affected and they can continue through their check with the flag value that was set at the beginning of their journey.
+
+To use the feature flag in your code, just call `FeatureFlags.enabled?(:flag_name)`. There is an optional `session_data` argument which you must use if you wish to derive the flag value from the `session_data`. Usage is `FeatureFlags.enabled?(:flag_name, session_data)`.
 
 In tests, you can temporarily enable a feature flag by setting the ENV value.
 However, flags are _not_ reset between specs, so to avoid polluting other tests use an `around` block and change the ENV value back once the test has run.

--- a/README.md
+++ b/README.md
@@ -148,9 +148,9 @@ Then add `flag_name` to the list of flags  in `app/lib/feature_flags.rb`.
 
 When adding a `flag_name` to the list of static flags, you will need to decide if this is a `"global"` flag i.e. always taken from the env var and not the session, or a `"session"` flag i.e. taken from the `session_data` of the check. 
 
-We introduced this as a way of making our feature flags 'backwards compatible' - if a user check is underway during the switch-on of a flag, their user journey will not be affected and they can continue through their check with the flag value that was set at the beginning of their journey.
+We introduced this as a way of making our feature flags 'backwards compatible' - if a user check is underway during the switch-on of a flag, their user journey will not be affected by any flag-related changes. This is because we use their `session_data` to determine the value of the flag that was set at the start of their check. 
 
-To use the feature flag in your code, just call `FeatureFlags.enabled?(:flag_name)`. There is an optional `session_data` argument which you must use if you wish to derive the flag value from the `session_data`. Usage is `FeatureFlags.enabled?(:flag_name, session_data)`.
+To use the feature flag in your code, call `FeatureFlags.enabled?(:flag_name, session_data)`. For cases where you are not able to pass in `session_data` e.g. on the start page, call `FeatureFlags.enabled?(:flag_name, without_session_data: true)`.
 
 In tests, you can temporarily enable a feature flag by setting the ENV value.
 However, flags are _not_ reset between specs, so to avoid polluting other tests use an `around` block and change the ENV value back once the test has run.

--- a/app/controllers/estimates_controller.rb
+++ b/app/controllers/estimates_controller.rb
@@ -66,7 +66,7 @@ private
   def load_session_derived_flags
     feature_flags = {}
     FeatureFlags::STATIC_FLAGS.select { |_, v| v == "session" }.map do |flag|
-      feature_flags[flag.first.to_s] = FeatureFlags.enabled?(flag.first)
+      feature_flags[flag.first.to_s] = FeatureFlags.enabled?(flag.first, without_session_data: true)
     end
 
     feature_flags

--- a/app/controllers/estimates_controller.rb
+++ b/app/controllers/estimates_controller.rb
@@ -3,7 +3,7 @@ class EstimatesController < ApplicationController
 
   def new
     new_assessment_code = SecureRandom.uuid
-    session[assessment_id(new_assessment_code)] = {}
+    session[assessment_id(new_assessment_code)] = { "feature_flags": load_session_derived_flags }
     redirect_to estimate_build_estimate_path new_assessment_code, Steps::Helper.first_step
   end
 
@@ -61,5 +61,14 @@ private
 
   def track_completed_journey(calculation_result)
     JourneyLoggerService.call(assessment_id, calculation_result, @check, cookies)
+  end
+
+  def load_session_derived_flags
+    feature_flags = {}
+    FeatureFlags::STATIC_FLAGS.select { |_, v| v == "session" }.map do |flag|
+      feature_flags[flag.first.to_s] = FeatureFlags.enabled?(flag.first)
+    end
+
+    feature_flags
   end
 end

--- a/app/controllers/estimates_controller.rb
+++ b/app/controllers/estimates_controller.rb
@@ -3,7 +3,7 @@ class EstimatesController < ApplicationController
 
   def new
     new_assessment_code = SecureRandom.uuid
-    session[assessment_id(new_assessment_code)] = { "feature_flags": load_session_derived_flags }
+    session[assessment_id(new_assessment_code)] = { "feature_flags" => load_session_derived_flags }
     redirect_to estimate_build_estimate_path new_assessment_code, Steps::Helper.first_step
   end
 

--- a/app/forms/applicant_form.rb
+++ b/app/forms/applicant_form.rb
@@ -3,6 +3,8 @@ class ApplicantForm
   include ActiveModel::Attributes
   include SessionPersistable
 
+  delegate :session_data, to: :check
+
   EMPLOYED_STATUSES = %i[in_work receiving_statutory_pay].freeze
   EMPLOYMENT_STATUSES = (EMPLOYED_STATUSES + %i[unemployed]).freeze
 
@@ -17,7 +19,7 @@ class ApplicantForm
   attribute :employment_status, :string
   validates :employment_status,
             inclusion: { in: EMPLOYMENT_STATUSES.map(&:to_s), allow_nil: false },
-            if: -> { !FeatureFlags.enabled?(:self_employed) }
+            if: -> { !FeatureFlags.enabled?(:self_employed, session_data) }
 
   attribute :partner, :boolean
   validates :partner, inclusion: { in: [true, false] }
@@ -26,7 +28,7 @@ class ApplicantForm
   validates :passporting, inclusion: { in: [true, false] }
 
   def attributes_for_export_to_session
-    if FeatureFlags.enabled?(:self_employed)
+    if FeatureFlags.enabled?(:self_employed, session_data)
       attributes.except!("employment_status")
     else
       attributes

--- a/app/forms/partner_details_form.rb
+++ b/app/forms/partner_details_form.rb
@@ -4,6 +4,7 @@ class PartnerDetailsForm
   include SessionPersistableForPartner
 
   delegate :passporting, to: :check
+  delegate :session_data, to: :check
 
   ATTRIBUTES = %i[over_60 employment_status].freeze
 
@@ -13,5 +14,5 @@ class PartnerDetailsForm
   attribute :employment_status, :string
   validates :employment_status,
             inclusion: { in: ApplicantForm::EMPLOYMENT_STATUSES.map(&:to_s), allow_nil: false },
-            if: -> { !passporting && !FeatureFlags.enabled?(:self_employed) }
+            if: -> { !passporting && !FeatureFlags.enabled?(:self_employed, session_data) }
 end

--- a/app/helpers/applicant_helper.rb
+++ b/app/helpers/applicant_helper.rb
@@ -5,7 +5,7 @@ module ApplicantHelper
       t("estimate_flow.applicant.pensioner_guidance.text") => t("estimate_flow.applicant.pensioner_guidance.#{check.level_of_help}.link"),
     }
 
-    return links unless !check.controlled? && FeatureFlags.enabled?(:special_applicant_groups)
+    return links unless !check.controlled? && FeatureFlags.enabled?(:special_applicant_groups, check.session_data)
 
     links.merge(
       t("estimate_flow.applicant.prisoner_guidance.text") => t("estimate_flow.applicant.prisoner_guidance.link"),

--- a/app/helpers/assets_helper.rb
+++ b/app/helpers/assets_helper.rb
@@ -1,21 +1,21 @@
 module AssetsHelper
-  def assets_links(level_of_help, smod_applicable)
+  def assets_links(check)
     links = {
-      t("estimate_flow.assets.guidance.#{level_of_help}.text") => t("estimate_flow.assets.guidance.#{level_of_help}.link"),
+      t("estimate_flow.assets.guidance.#{check.level_of_help}.text") => t("estimate_flow.assets.guidance.#{check.level_of_help}.link"),
     }
 
-    if level_of_help == "certificated"
+    if check.level_of_help == "certificated"
       links[t("estimate_flow.assets.disregarded_capital_guidance.text")] = t("estimate_flow.assets.disregarded_capital_guidance.link")
 
-      if FeatureFlags.enabled?(:special_applicant_groups)
+      if FeatureFlags.enabled?(:special_applicant_groups, check.session_data)
         links[t("estimate_flow.assets.prisoner_guidance.text")] = t("estimate_flow.assets.prisoner_guidance.link")
         links[t("estimate_flow.assets.bankrupt_guidance.text")] = t("estimate_flow.assets.bankrupt_guidance.link")
       end
     end
 
-    return links unless smod_applicable
+    return links unless check.smod_applicable?
 
-    links.merge({ t("generic.smod.guidance.text") => t("generic.smod.guidance.#{level_of_help}.link") })
+    links.merge({ t("generic.smod.guidance.text") => t("generic.smod.guidance.#{check.level_of_help}.link") })
   end
 
   def partner_assets_links(check)
@@ -23,7 +23,7 @@ module AssetsHelper
       t("estimate_flow.assets.guidance.#{check.level_of_help}.text") => t("estimate_flow.assets.guidance.#{check.level_of_help}.link"),
     }
 
-    return links unless FeatureFlags.enabled?(:special_applicant_groups) && !check.controlled?
+    return links unless FeatureFlags.enabled?(:special_applicant_groups, check.session_data) && !check.controlled?
 
     links.merge(
       t("estimate_flow.partner_assets.prisoner_guidance.text") => t("estimate_flow.assets.prisoner_guidance.link"),

--- a/app/helpers/employment_helper.rb
+++ b/app/helpers/employment_helper.rb
@@ -1,6 +1,6 @@
 module EmploymentHelper
   def employment_links(check, partner: false)
-    return {} unless FeatureFlags.enabled?(:special_applicant_groups)
+    return {} unless FeatureFlags.enabled?(:special_applicant_groups, check.session_data)
 
     if check.controlled?
       {

--- a/app/lib/feature_flags.rb
+++ b/app/lib/feature_flags.rb
@@ -3,10 +3,17 @@ class FeatureFlags
     example_2125_flag: { from: "2125-01-01", public: false },
   }.freeze
 
-  STATIC_FLAGS = %i[sentry cw_forms special_applicant_groups self_employed public_beta].freeze
+  # the values of some feature flags will come from the session and not the env variables.
+  # "global" - feature flag value should be derived from the env variable
+  # "session" - feature flag value should be derived from the session_data of the check
+  STATIC_FLAGS = { sentry: "global", cw_forms: "global", special_applicant_groups: "session", self_employed: "session", public_beta: "global" }.freeze
 
   class << self
-    def enabled?(flag)
+    def enabled?(flag, session_data = nil)
+      if session_data && session_data["feature_flags"]&.key?(flag.to_s)
+        return session_data["feature_flags"][flag.to_s]
+      end
+
       if overrideable?
         override = FeatureFlagOverride.find_by(key: flag)
         if override
@@ -14,10 +21,10 @@ class FeatureFlags
         end
       end
 
-      if ENABLED_AFTER_DATE.key?(flag)
-        Time.current.beginning_of_day >= ENABLED_AFTER_DATE.dig(flag, :from)
-      elsif STATIC_FLAGS.include?(flag)
+      if STATIC_FLAGS.key?(flag)
         ENV["#{flag.to_s.upcase}_FEATURE_FLAG"]&.casecmp("enabled")&.zero? || false
+      elsif ENABLED_AFTER_DATE.key?(flag)
+        Time.current.beginning_of_day >= ENABLED_AFTER_DATE.dig(flag, :from)
       else
         raise "Unrecognised flag '#{flag}'"
       end
@@ -28,7 +35,7 @@ class FeatureFlags
     end
 
     def static
-      STATIC_FLAGS
+      STATIC_FLAGS.keys
     end
 
     def overrideable?

--- a/app/lib/feature_flags.rb
+++ b/app/lib/feature_flags.rb
@@ -16,7 +16,11 @@ class FeatureFlags
   }.freeze
 
   class << self
-    def enabled?(flag, session_data = nil)
+    def enabled?(flag, session_data = nil, without_session_data: false)
+      if session_data.nil? && !without_session_data
+        raise "Pass in session_data or set without_session_data to true"
+      end
+
       if session_data && session_data["feature_flags"]&.key?(flag.to_s)
         return session_data["feature_flags"][flag.to_s]
       end

--- a/app/lib/feature_flags.rb
+++ b/app/lib/feature_flags.rb
@@ -6,7 +6,14 @@ class FeatureFlags
   # the values of some feature flags will come from the session and not the env variables.
   # "global" - feature flag value should be derived from the env variable
   # "session" - feature flag value should be derived from the session_data of the check
-  STATIC_FLAGS = { sentry: "global", cw_forms: "global", special_applicant_groups: "session", self_employed: "session", public_beta: "global" }.freeze
+  STATIC_FLAGS = {
+    example: "session",
+    sentry: "global",
+    cw_forms: "global",
+    special_applicant_groups: "session",
+    self_employed: "session",
+    public_beta: "global",
+  }.freeze
 
   class << self
     def enabled?(flag, session_data = nil)

--- a/app/lib/steps/income_section.rb
+++ b/app/lib/steps/income_section.rb
@@ -9,7 +9,7 @@ module Steps
         if Steps::Logic.passported?(session_data) || Steps::Logic.asylum_supported?(session_data)
           []
         else
-          [employment_status_step,
+          [employment_status_step(session_data),
            employment_steps(session_data),
            benefit_steps(session_data),
            Steps::Group.new(:other_income)].compact
@@ -23,8 +23,8 @@ module Steps
         Steps::Group.new(key) if Steps::Logic.employed?(session_data)
       end
 
-      def employment_status_step
-        return unless FeatureFlags.enabled?(:self_employed)
+      def employment_status_step(session_data)
+        return unless FeatureFlags.enabled?(:self_employed, session_data)
 
         Steps::Group.new(:employment_status)
       end

--- a/app/lib/steps/income_section.rb
+++ b/app/lib/steps/income_section.rb
@@ -19,7 +19,7 @@ module Steps
     private
 
       def employment_steps(session_data)
-        key = FeatureFlags.enabled?(:self_employed) ? :income : :employment
+        key = FeatureFlags.enabled?(:self_employed, session_data) ? :income : :employment
         Steps::Group.new(key) if Steps::Logic.employed?(session_data)
       end
 

--- a/app/lib/steps/logic.rb
+++ b/app/lib/steps/logic.rb
@@ -47,7 +47,7 @@ module Steps
       def employed?(session_data)
         return false if asylum_supported?(session_data) || passported?(session_data)
 
-        employment_statuses = FeatureFlags.enabled?(:self_employed) ? EmploymentStatusForm::EMPLOYED_STATUSES : ApplicantForm::EMPLOYED_STATUSES
+        employment_statuses = FeatureFlags.enabled?(:self_employed, session_data) ? EmploymentStatusForm::EMPLOYED_STATUSES : ApplicantForm::EMPLOYED_STATUSES
 
         employment_statuses.map(&:to_s).include? session_data["employment_status"]
       end
@@ -71,7 +71,7 @@ module Steps
       def partner_employed?(session_data)
         return false if passported?(session_data) || !partner?(session_data)
 
-        employment_statuses = FeatureFlags.enabled?(:self_employed) ? EmploymentStatusForm::EMPLOYED_STATUSES : ApplicantForm::EMPLOYED_STATUSES
+        employment_statuses = FeatureFlags.enabled?(:self_employed, session_data) ? EmploymentStatusForm::EMPLOYED_STATUSES : ApplicantForm::EMPLOYED_STATUSES
 
         employment_statuses.map(&:to_s).include? session_data["partner_employment_status"]
       end

--- a/app/lib/steps/partner_section.rb
+++ b/app/lib/steps/partner_section.rb
@@ -19,7 +19,7 @@ module Steps
           [Steps::Group.new(:partner_details)]
         else
           [Steps::Group.new(:partner_details),
-           employment_status_step,
+           employment_status_step(session_data),
            employment_steps(session_data),
            benefit_steps(session_data),
            Steps::Group.new(:partner_other_income)].compact
@@ -28,8 +28,8 @@ module Steps
 
     private
 
-      def employment_status_step
-        Steps::Group.new(:partner_employment_status) if FeatureFlags.enabled?(:self_employed)
+      def employment_status_step(session_data)
+        Steps::Group.new(:partner_employment_status) if FeatureFlags.enabled?(:self_employed, session_data)
       end
 
       def employment_steps(session_data)

--- a/app/lib/steps/partner_section.rb
+++ b/app/lib/steps/partner_section.rb
@@ -33,7 +33,7 @@ module Steps
       end
 
       def employment_steps(session_data)
-        key = FeatureFlags.enabled?(:self_employed) ? :partner_income : :partner_employment
+        key = FeatureFlags.enabled?(:self_employed, session_data) ? :partner_income : :partner_employment
         Steps::Group.new(key) if Steps::Logic.partner_employed?(session_data)
       end
 

--- a/app/models/check.rb
+++ b/app/models/check.rb
@@ -81,7 +81,7 @@ class Check
   end
 
   def self_employed_flag_enabled?
-    FeatureFlags.enabled?(:self_employed)
+    FeatureFlags.enabled?(:self_employed, session_data)
   end
 
   def immigration_matter?

--- a/app/services/cfe/employment_income_payload_service.rb
+++ b/app/services/cfe/employment_income_payload_service.rb
@@ -1,7 +1,7 @@
 module Cfe
   class EmploymentIncomePayloadService < BaseService
     def call
-      if FeatureFlags.enabled?(:self_employed)
+      if FeatureFlags.enabled?(:self_employed, @session_data)
         income_payload
       else
         employment_payload

--- a/app/services/error_service.rb
+++ b/app/services/error_service.rb
@@ -1,7 +1,7 @@
 class ErrorService
   class << self
     def call(exception)
-      if FeatureFlags.enabled?(:sentry)
+      if FeatureFlags.enabled?(:sentry, without_session_data: true)
         Sentry.capture_exception(exception)
       else
         ExceptionNotifier::TemplatedNotifier.new.call(exception)

--- a/app/views/estimate_flow/applicant.html.slim
+++ b/app/views/estimate_flow/applicant.html.slim
@@ -2,13 +2,14 @@
   = t(".heading")
 - content_for :back do
   = back_link(:applicant, @check, @back_buttons_invoke_browser_back_behaviour)
+- special_applicants = FeatureFlags.enabled?(:special_applicant_groups, @check.session_data)
 
 - content_for :partner_hint
   p.govuk-hint = t(".partner.hint_text")
   ul.govuk-list.govuk-list--bullet
     - t(".partner.hint_list").each
       li.govuk-hint = _1
-    li.govuk-hint = t(".partner.last_hint#{'_no_special_applicants' unless FeatureFlags.enabled?(:special_applicant_groups)}")
+    li.govuk-hint = t(".partner.last_hint#{'_no_special_applicants' unless special_applicants}")
   p.govuk-hint = t(".partner.partner_additional.hint_text")
   ul.govuk-list.govuk-list--bullet
     - t(".partner.partner_additional.hint_list").each
@@ -35,8 +36,8 @@
               link_errors: true
       = form.govuk_radio_button :partner, false, label: { text: t("generic.no_choice") }
 
-    - unless FeatureFlags.enabled?(:self_employed)
-      - hint_key = FeatureFlags.enabled?(:special_applicant_groups) ? "hint" : "hint_no_special_applicants"
+    - unless FeatureFlags.enabled?(:self_employed, @check.session_data)
+      - hint_key = special_applicants ? "hint" : "hint_no_special_applicants"
       = form.govuk_collection_radio_buttons :employment_status, employment_options, :first, :last,
                                             legend: { text: t(".employed.legend") },
                                             hint: { text: t(".employed.#{hint_key}") }

--- a/app/views/estimate_flow/assets.html.slim
+++ b/app/views/estimate_flow/assets.html.slim
@@ -11,4 +11,4 @@
 
 = render "shared/question_sidebar",
         level_of_help: @check.level_of_help,
-        links: assets_links(@check.level_of_help, @check.smod_applicable?)
+        links: assets_links(@check)

--- a/app/views/estimate_flow/forms/_assets.html.slim
+++ b/app/views/estimate_flow/forms/_assets.html.slim
@@ -14,8 +14,8 @@
               post_header_texts: hints,
               tag: (:partner if partner)
 
-    - if FeatureFlags.enabled?(:special_applicant_groups)
-      - if FeatureFlags.enabled?(:self_employed) && !@check.controlled? && \
+    - if FeatureFlags.enabled?(:special_applicant_groups, @check.session_data)
+      - if FeatureFlags.enabled?(:self_employed, @check.session_data) && !@check.controlled? && \
         ((partner && @check.partner_self_employed?) || (!partner && @check.client_self_employed?))
         = govuk_details(summary_text: t("estimate_flow.#{i18n_key}.business_capital_title"))
           p.govuk-text = t("estimate_flow.#{i18n_key}.business_capital_text")

--- a/app/views/estimate_flow/forms/_employment.html.slim
+++ b/app/views/estimate_flow/forms/_employment.html.slim
@@ -7,7 +7,7 @@
             post_header_text: t("estimate_flow.#{i18n_key}.second_caption"),
             tag: (:partner if partner)
 
-  - if FeatureFlags.enabled?(:special_applicant_groups)
+  - if FeatureFlags.enabled?(:special_applicant_groups, @check.session_data)
     = govuk_details(summary_text: t("estimate_flow.#{i18n_key}.police_officer_heading"))
       p.govuk-text = t("estimate_flow.#{i18n_key}.police_officer_hint")
       ul.govuk-list.govuk-list--bullet

--- a/app/views/estimate_flow/forms/_income.html.slim
+++ b/app/views/estimate_flow/forms/_income.html.slim
@@ -9,7 +9,7 @@
               header_text: t("estimate_flow.#{i18n_key}.heading"),
               post_header_text: t("estimate_flow.#{i18n_key}.hint"),
               tag: (:partner if partner)
-    - if FeatureFlags.enabled?(:special_applicant_groups)
+    - if FeatureFlags.enabled?(:special_applicant_groups, @check.session_data)
       = govuk_details(summary_text: t("estimate_flow.#{i18n_key}.police_officer_heading"))
         p.govuk-text = t("estimate_flow.#{i18n_key}.police_officer_hint")
         ul.govuk-list.govuk-list--bullet

--- a/app/views/estimate_flow/partner_details.html.slim
+++ b/app/views/estimate_flow/partner_details.html.slim
@@ -16,8 +16,8 @@
             legend: { text: t("estimate_flow.partner_details.partner_over_60.legend") },
             hint: { text: t("estimate_flow.partner_details.partner_over_60.hint") }
 
-    - if !@check.passporting && !FeatureFlags.enabled?(:self_employed)
-      - hint_key = FeatureFlags.enabled?(:special_applicant_groups) ? "hint" : "hint_no_special_applicants"
+    - if !@check.passporting && !FeatureFlags.enabled?(:self_employed, @check.session_data)
+      - hint_key = FeatureFlags.enabled?(:special_applicant_groups, @check.session_data) ? "hint" : "hint_no_special_applicants"
       = form.govuk_collection_radio_buttons :employment_status, employment_options, :first, :last,
                   legend: { text: t("estimate_flow.partner_details.partner_employed.legend") },
                   hint: { text: t("estimate_flow.partner_details.partner_employed.#{hint_key}") }

--- a/app/views/estimate_flow/property.html.slim
+++ b/app/views/estimate_flow/property.html.slim
@@ -9,7 +9,7 @@
     = form.govuk_error_summary t("generic.error_summary_title")
 
     = render "shared/household_tag"
-    - if FeatureFlags.enabled?(:special_applicant_groups) && @check.partner
+    - if FeatureFlags.enabled?(:special_applicant_groups, @check.session_data) && @check.partner
       = form.govuk_collection_radio_buttons :property_owned, property_options, :first, :last,
                                             legend: { text: t(legend_key), size: "xl", tag: "h1" },
                                             hint: lambda { \

--- a/app/views/estimates/_evidence.html.slim
+++ b/app/views/estimates/_evidence.html.slim
@@ -1,3 +1,4 @@
+- special_applicants = FeatureFlags.enabled?(:special_applicant_groups, @check.session_data)
 - if @check.asylum_support
   ul.govuk-list.govuk-list--bullet
     - t("estimates.show.controlled_asylum_types_of_evidence").each_with_index do |evidence, index|
@@ -7,20 +8,20 @@
           ul
             - t("estimates.show.controlled_asylum_subtypes_of_evidence").each do |subevidence|
               li = subevidence
-- elsif @model.level_of_help == "controlled" && !FeatureFlags.enabled?(:self_employed)
+- elsif @model.level_of_help == "controlled" && !FeatureFlags.enabled?(:self_employed, @check.session_data)
   p.govuk-body = t("estimates.show.evidence_needed_explainer#{'_partner' if @check.partner}")
   ul.govuk-list.govuk-list--bullet
     - t("estimates.show.legacy_controlled_types_of_evidence#{'_partner' if @check.partner}").each do |evidence|
       li = evidence
-- elsif @model.level_of_help == "controlled" && FeatureFlags.enabled?(:self_employed)
+- elsif @model.level_of_help == "controlled" && FeatureFlags.enabled?(:self_employed, @check.session_data)
   p.govuk-body = t("estimates.show.evidence_needed_explainer#{'_partner' if @check.partner}")
   ul.govuk-list.govuk-list--bullet
     - t("estimates.show.controlled_types_of_evidence#{'_partner' if @check.partner}").each do |evidence|
       li = evidence
-- elsif FeatureFlags.enabled?(:self_employed)
+- elsif FeatureFlags.enabled?(:self_employed, @check.session_data)
   p.govuk-body = t("estimates.show.evidence_needed_explainer")
   ul.govuk-list.govuk-list--bullet
-    - t("estimates.show.#{'legacy_' unless FeatureFlags.enabled?(:special_applicant_groups)}types_of_evidence").each do |evidence|
+    - t("estimates.show.#{'legacy_' unless special_applicants}types_of_evidence").each do |evidence|
       li.govuk-body = evidence
   p.govuk-body = t("estimates.show.self_employed_evidence_needed_explainer")
   ul.govuk-list.govuk-list--bullet
@@ -29,5 +30,5 @@
 - else
   p.govuk-body = t("estimates.show.evidence_needed_explainer")
   ul.govuk-list.govuk-list--bullet
-    - t("estimates.show.#{'legacy_' unless FeatureFlags.enabled?(:special_applicant_groups)}types_of_evidence").each do |evidence|
+    - t("estimates.show.#{'legacy_' unless special_applicants}types_of_evidence").each do |evidence|
       li.govuk-body = evidence

--- a/app/views/estimates/print.html.slim
+++ b/app/views/estimates/print.html.slim
@@ -33,7 +33,7 @@
     = render "evidence"
   - elsif @model.level_of_help == "controlled" && @model.decision == "eligible"
     h2.govuk-heading-m = t("estimates.show.what_happens_next")
-    - if FeatureFlags.enabled?(:cw_forms)
+    - if FeatureFlags.enabled?(:cw_forms, @check.session_data)
       = render "controlled_work_next_steps"
     - else
       p.govuk-body = t("estimates.show.controlled_next_steps_paragraph_1#{'_partner' if @check.partner}")

--- a/app/views/estimates/show.html.slim
+++ b/app/views/estimates/show.html.slim
@@ -23,7 +23,7 @@
     = render "evidence"
 - elsif @model.level_of_help == "controlled" && @model.decision == "eligible"
   h2.govuk-heading-m = t(".what_happens_next")
-  - if FeatureFlags.enabled?(:cw_forms)
+  - if FeatureFlags.enabled?(:cw_forms, @check.session_data)
     = render "controlled_work_next_steps"
   - else
     p.govuk-body = t(".controlled_next_steps_paragraph_1#{'_partner' if @check.partner}")
@@ -54,7 +54,7 @@
         = render "capital_table", caption_size: "m"
 
 .govuk-button-group
-  - if @model.level_of_help == "controlled" && @model.decision == "eligible" && FeatureFlags.enabled?(:cw_forms)
+  - if @model.level_of_help == "controlled" && @model.decision == "eligible" && FeatureFlags.enabled?(:cw_forms, @check.session_data)
     = link_to t(".continue_to_cw"), new_estimate_controlled_work_document_selection_path(params[:id]), class: "govuk-button", data: { module: "govuk-button" }
   - else
     = link_to t(".start_another_check"), new_estimate_path, class: "govuk-button", data: { module: "govuk-button" }

--- a/app/views/feature_flags/index.html.slim
+++ b/app/views/feature_flags/index.html.slim
@@ -12,7 +12,7 @@
         FeatureFlags.time_dependant.each do |flag|
           body.with_row do |row|
             row.with_cell(text: flag)
-            row.with_cell(text: FeatureFlags.enabled?(flag) ? t("generic.yes_choice") : t("generic.no_choice"))
+            row.with_cell(text: FeatureFlags.enabled?(flag, without_session_data: true) ? t("generic.yes_choice") : t("generic.no_choice"))
             row.with_cell(text: link_to(t(".override"), edit_feature_flag_path(flag))) if FeatureFlags.overrideable?
           end
         end
@@ -29,7 +29,7 @@
         FeatureFlags.static.each do |flag|
           body.with_row do |row|
             row.with_cell(text: flag)
-            row.with_cell(text: FeatureFlags.enabled?(flag) ? t("generic.yes_choice") : t("generic.no_choice"))
+            row.with_cell(text: FeatureFlags.enabled?(flag, without_session_data: true) ? t("generic.yes_choice") : t("generic.no_choice"))
             row.with_cell(text: link_to(t(".override"), edit_feature_flag_path(flag))) if FeatureFlags.overrideable?
           end
         end

--- a/app/views/layouts/_footer.html.slim
+++ b/app/views/layouts/_footer.html.slim
@@ -7,7 +7,7 @@ footer.govuk-footer.no-print role="contentinfo"
 
         h2.govuk-visually-hidden = t("layouts.application.footer.support")
         ul.govuk-footer__inline-list
-          - if FeatureFlags.enabled?(:public_beta)
+          - if FeatureFlags.enabled?(:public_beta, without_session_data: true)
             li.govuk-footer__inline-list-item
               = link_to t("layouts.application.footer.help"), help_path, class: "govuk-footer__link"
           - else

--- a/app/views/start/index.html.slim
+++ b/app/views/start/index.html.slim
@@ -9,7 +9,7 @@
   .govuk-inset-text = t(".only_for_legal_aid_providers_html",
                          link: link_to(t(".check_if_you_can_get_legal_aid"), "https://www.gov.uk/check-legal-aid"))
 
-  - if FeatureFlags.enabled?(:special_applicant_groups)
+  - if FeatureFlags.enabled?(:special_applicant_groups, without_session_data: true)
     p.govuk-body = t(".partner_living_outside_uk_html")
 
   h2.govuk-heading-m = t(".case_types")
@@ -21,15 +21,15 @@
   p.govuk-body = t(".mental_health_html")
 
   h2.govuk-heading-m = t(".client_types")
-  - if FeatureFlags.enabled?(:special_applicant_groups)
-    - unless FeatureFlags.enabled?(:self_employed)
+  - if FeatureFlags.enabled?(:special_applicant_groups, without_session_data: true)
+    - unless FeatureFlags.enabled?(:self_employed, without_session_data: true)
       h3.govuk-heading-s = t(".self_employment")
       p.govuk-body = t(".unacceptable_client_explanation")
     h3.govuk-heading-s = t(".unacceptable_client_heading_under_18")
     p.govuk-body
       - t(".unacceptable_client_explanation_under_18_html").each
         p.govuk-body = _1
-    - if FeatureFlags.enabled?(:self_employed)
+    - if FeatureFlags.enabled?(:self_employed, without_session_data: true)
       h3.govuk-heading-s = t(".unacceptable_client_heading_company_director")
       p.govuk-body = t(".unacceptable_client_explanation_company_director")
 

--- a/spec/features/feature_flags_spec.rb
+++ b/spec/features/feature_flags_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe "Feature flags" do
       allow(FeatureFlags).to receive(:static).and_return(%i[static_flag])
       allow(FeatureFlags).to receive(:time_dependant).and_return(%i[time_dependant_flag])
       allow(FeatureFlags).to receive(:enabled?).and_return(false)
-      allow(FeatureFlags).to receive(:enabled?).with(:static_flag).and_return(true)
-      allow(FeatureFlags).to receive(:enabled?).with(:time_dependant_flag).and_return(false)
+      allow(FeatureFlags).to receive(:enabled?).with(:static_flag, without_session_data: true).and_return(true)
+      allow(FeatureFlags).to receive(:enabled?).with(:time_dependant_flag, without_session_data: true).and_return(false)
     end
 
     scenario "I see all public feature flags" do
@@ -45,19 +45,19 @@ RSpec.describe "Feature flags" do
       page.driver.browser.basic_authorize("flags", "password")
       visit feature_flags_path
       expect(page).to have_content "sentryNo"
-      expect(FeatureFlags.enabled?(:sentry)).to eq false
+      expect(FeatureFlags.enabled?(:sentry, without_session_data: true)).to eq false
 
       visit edit_feature_flag_path("sentry")
       choose "Yes"
       click_on "Save and continue"
       expect(page).to have_content "sentryYes"
-      expect(FeatureFlags.enabled?(:sentry)).to eq true
+      expect(FeatureFlags.enabled?(:sentry, without_session_data: true)).to eq true
 
       visit edit_feature_flag_path("sentry")
       choose "No"
       click_on "Save and continue"
       expect(page).to have_content "sentryNo"
-      expect(FeatureFlags.enabled?(:sentry)).to eq false
+      expect(FeatureFlags.enabled?(:sentry, without_session_data: true)).to eq false
     end
   end
 

--- a/spec/features/feature_flags_spec.rb
+++ b/spec/features/feature_flags_spec.rb
@@ -60,4 +60,18 @@ RSpec.describe "Feature flags" do
       expect(FeatureFlags.enabled?(:sentry)).to eq false
     end
   end
+
+  context "when setting feature flags in the session" do
+    around do |example|
+      ENV["EXAMPLE_FEATURE_FLAG"] = "enabled"
+      example.run
+      ENV["EXAMPLE_FEATURE_FLAG"] = "disabled"
+    end
+
+    scenario "I have session feature flags set in the session" do
+      visit "estimates/new"
+      expect(session_contents[:feature_flags]).to include({ "example" => true })
+      expect(session_contents[:feature_flags]).not_to include({ "sentry" => false })
+    end
+  end
 end

--- a/spec/features/feature_flags_spec.rb
+++ b/spec/features/feature_flags_spec.rb
@@ -70,8 +70,8 @@ RSpec.describe "Feature flags" do
 
     scenario "I have session feature flags set in the session" do
       visit "estimates/new"
-      expect(session_contents[:feature_flags]).to include({ "example" => true })
-      expect(session_contents[:feature_flags]).not_to include({ "sentry" => false })
+      expect(session_contents["feature_flags"]).to include({ "example" => true })
+      expect(session_contents["feature_flags"]).not_to include({ "sentry" => false })
     end
   end
 end

--- a/spec/models/feature_flags_spec.rb
+++ b/spec/models/feature_flags_spec.rb
@@ -4,12 +4,12 @@ RSpec.describe FeatureFlags do
   describe "example_2125_flag flag" do
     it "returns false before it comes into effect" do
       travel_to "2124-12-31"
-      expect(described_class.enabled?(:example_2125_flag)).to eq false
+      expect(described_class.enabled?(:example_2125_flag, without_session_data: true)).to eq false
     end
 
     it "returns true when it comes into effect" do
       travel_to "2125-01-01"
-      expect(described_class.enabled?(:example_2125_flag)).to eq true
+      expect(described_class.enabled?(:example_2125_flag, without_session_data: true)).to eq true
     end
   end
 
@@ -42,7 +42,11 @@ RSpec.describe FeatureFlags do
   end
 
   it "errors on unrecognised flags" do
-    expect { described_class.enabled?(:unknown_flag) }.to raise_error "Unrecognised flag 'unknown_flag'"
+    expect { described_class.enabled?(:unknown_flag, without_session_data: true) }.to raise_error "Unrecognised flag 'unknown_flag'"
+  end
+
+  it "errors when there is no session_data and without_session_data is not set to true" do
+    expect { described_class.enabled?(:sentry) }.to raise_error "Pass in session_data or set without_session_data to true"
   end
 
   describe ".static" do

--- a/spec/models/feature_flags_spec.rb
+++ b/spec/models/feature_flags_spec.rb
@@ -13,6 +13,30 @@ RSpec.describe FeatureFlags do
     end
   end
 
+  describe "global and session flags" do
+    let(:session_data) { { "feature_flags" => {} } }
+
+    context "when global flag is switched on do" do
+      around do |each|
+        ENV["SENTRY_FEATURE_FLAG"] = "enabled"
+        each.run
+        ENV["SENTRY_FEATURE_FLAG"] = "disabled"
+      end
+
+      it "defaults to global flag when the flag does not exist in the session_data" do
+        expect(described_class.enabled?(:sentry, session_data)).to eq true
+      end
+
+      context "when flag is specified in the session_data" do
+        let(:session_data) { { "feature_flags" => { "sentry" => false } } }
+
+        it "returns the value from the session_data" do
+          expect(described_class.enabled?(:sentry, session_data)).to eq false
+        end
+      end
+    end
+  end
+
   it "contains no out of date flags" do
     expect(described_class::ENABLED_AFTER_DATE.values.count { 1.month.ago > _1[:from] }).to eq 0
   end
@@ -23,7 +47,7 @@ RSpec.describe FeatureFlags do
 
   describe ".static" do
     it "returns all static flags" do
-      expect(described_class.static).to eq FeatureFlags::STATIC_FLAGS
+      expect(described_class.static).to eq FeatureFlags::STATIC_FLAGS.keys
     end
   end
 

--- a/spec/services/error_service_spec.rb
+++ b/spec/services/error_service_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe ErrorService do
     let(:exception) { :exception }
 
     context "when sentry is enabled" do
-      before { allow(FeatureFlags).to receive(:enabled?).with(:sentry).and_return(true) }
+      before { allow(FeatureFlags).to receive(:enabled?).with(:sentry, without_session_data: true).and_return(true) }
 
       it "passes the exception to Sentry" do
         expect(Sentry).to receive(:capture_exception).with(exception)
@@ -15,7 +15,7 @@ RSpec.describe ErrorService do
     end
 
     context "when sentry is not enabled" do
-      before { allow(FeatureFlags).to receive(:enabled?).with(:sentry).and_return(false) }
+      before { allow(FeatureFlags).to receive(:enabled?).with(:sentry, without_session_data: true).and_return(false) }
 
       it "passes the exception to ExceptionNotifier" do
         notifier = instance_double("ExceptionNotifier::TemplatedNotifier")


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-961)

## What changed and why

For some types of feature flags, we will now derive the value of these from the session_data on the check object. This is so that flags can be backwards compatible, and eliminate errors associated with a flag being switched on when a user check is still underway. 

Relevant flag values i.e. those changing content/flow that are not policy specific, are stored on the session_data at the beginning of a check. These are then used to determine the flag value throughout the check.

I believe time-based flags are policy specific so these are not stored on the session_data. And not all static flags would affect the user flow (cw form flag for example). So I think we need to think about whether the flag is a global flag or a session flag on a case by case basis.

There are now three arguments that can be passed into `def enabled?` which are the flag name, `session_data` (if applicable) and a keyword argument of `without_session_data`. Although it isn't technically required, always pass in `session_data` when you can. In places where you cannot pass it in, pass in `without_session_data: true`. Usage is:

`FeatureFlags.enabled?(:flag, session_data)`
`FeatureFlags.enabled?(:flag, without_session_data: true)`

## Guidance to review

Check the places where I have passed in `session_data` to `FeatureFlags.enabled?` and make sure it makes sense
Make sure the README makes sense!

I'm not sure if `without_session_data` is the best naming so open to any other suggestions/implementation!

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
