### PR TITLE
EL-989: Only show self-employed help on assets screen for certificated

### DIFF
--- a/app/views/estimate_flow/forms/_assets.html.slim
+++ b/app/views/estimate_flow/forms/_assets.html.slim
@@ -16,7 +16,7 @@
 
     - if FeatureFlags.enabled?(:special_applicant_groups)
       /! TODO: the check below needs to be amended to include a check that ‘Self-employment income' has been selected (EL-943/EL-947)
-      - if FeatureFlags.enabled?(:self_employed)
+      - if FeatureFlags.enabled?(:self_employed) && !@check.controlled?
         = govuk_details(summary_text: t("estimate_flow.#{i18n_key}.business_capital_title"))
           p.govuk-text = t("estimate_flow.#{i18n_key}.business_capital_text")
           p.govuk-text = t("estimate_flow.#{i18n_key}.business_capital_text_html")

--- a/helm_deploy/laa-estimate-eligibility/values/uat.yaml
+++ b/helm_deploy/laa-estimate-eligibility/values/uat.yaml
@@ -43,6 +43,9 @@ ingress:
     external-dns.alpha.kubernetes.io/aws-weight: "100"
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
 
+deploy:
+  host: main-check-client-qualifies-legal-aid-uat.cloud-platform.service.justice.gov.uk
+
 notifications:
   errorMessageTemplateId: b8879191-e4bb-4f10-831a-7d9bd2b078f1
   recipient: patrick.gleeson@digital.justice.gov.uk,michael.blatherwick@digital.justice.gov.uk,stephen.p.dicks@digital.justice.gov.uk,william.clarke@digital.justice.gov.uk

--- a/spec/forms/assets_form_spec.rb
+++ b/spec/forms/assets_form_spec.rb
@@ -2,7 +2,8 @@ require "rails_helper"
 
 RSpec.describe "assets", type: :feature do
   let(:assessment_code) { :assessment_code }
-  let(:session) { { "level_of_help" => "controlled" } }
+  let(:level_of_help) { "controlled" }
+  let(:session) { { "level_of_help" => level_of_help } }
 
   before do
     set_session(assessment_code, session)
@@ -63,11 +64,17 @@ RSpec.describe "assets", type: :feature do
       it "shows appropriate links" do
         expect(page).to have_content "Guidance on bankrupt clients"
       end
+
+      context "when self_employed flag enabled", :self_employed_flag do
+        it "shows content about self-employed applicants" do
+          expect(page).to have_content "Business capital for self-employed clients"
+        end
+      end
     end
 
     context "when self_employed flag enabled", :self_employed_flag do
-      it "shows content about self-employed applicants" do
-        expect(page).to have_content "Business capital for self-employed clients"
+      it "does not show content about self-employed applicants" do
+        expect(page).not_to have_content "Business capital for self-employed clients"
       end
     end
   end


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-989)

## What changed and why

Ensure certificated-specific helptext is only shown for certificated checks

## Guidance to review

<!-- anything useful to let the reviewer know? -->

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
