### PR TITLE
BUG: Main UAT deployments failing

### DIFF
--- a/helm_deploy/laa-estimate-eligibility/values/uat.yaml
+++ b/helm_deploy/laa-estimate-eligibility/values/uat.yaml
@@ -39,7 +39,10 @@ securityContext:
   runAsUser: 1000
 
 ingress:
+  hosts:
+    - main-check-client-qualifies-legal-aid-uat.cloud-platform.service.justice.gov.uk
   annotations:
+    external-dns.alpha.kubernetes.io/set-identifier: "main-laa-estimate-eligibility-laa-estimate-financial-eligibility-for-legal-aid-uat-green"
     external-dns.alpha.kubernetes.io/aws-weight: "100"
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
 


### PR DESCRIPTION
## What changed and why

Previously, both branch deployments and main UAT deployments used the same `helm upgrade` command that explicitly set some dynamic values with `--set` arguments. However, now main UAT deployments use the `helm upgrade` command that staging and production deployments use, which assumes those values will be available in the values yaml file. So to get it working, we need the right values in the UAT values yaml file (which will still be overridden by the dynamic values provided on branch deployments).

Added viable default values to uat.yaml

## Guidance to review

<!-- anything useful to let the reviewer know? -->

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
