### PR TITLE
EL-1006: Add percentage signs to percentages on check answers page

### DIFF
--- a/app/lib/check_answers_fields.yml
+++ b/app/lib/check_answers_fields.yml
@@ -20,7 +20,7 @@
 # It also has zero or more fields
 
 # FIELDS
-# A field has a type, which is one of boolean, money, select, number or money_with_frequency.
+# A field has a type, which is one of boolean, money, select, number, percentage or money_with_frequency.
 # This determines which partial is rendered
 # It has an attribute, which determines the key used to store the relevant value in the session
 # The attribute is also used to construct the I18n key
@@ -249,7 +249,7 @@ sections:
           - type: money
             attribute: mortgage
             skip_unless: property_owned_with_mortgage?
-          - type: number
+          - type: percentage
             attribute: percentage_owned
             screen: property_entry
       - label: housing_costs
@@ -279,7 +279,7 @@ sections:
           - type: money
             attribute: additional_mortgage
             skip_unless: additional_property_owned_with_mortgage?
-          - type: number
+          - type: percentage
             attribute: additional_percentage_owned
             screen: additional_property_details
       - label: partner_additional_property
@@ -293,6 +293,6 @@ sections:
           - type: money
             attribute: partner_additional_mortgage
             skip_unless: partner_additional_property_owned_with_mortgage?
-          - type: number
+          - type: percentage
             attribute: partner_additional_percentage_owned
             screen: partner_additional_property_details

--- a/app/views/estimates/_check_answer.html.slim
+++ b/app/views/estimates/_check_answer.html.slim
@@ -1,3 +1,4 @@
+- disputed_asset ||= false
 .govuk-summary-list__row
   dt.govuk-summary-list__key
     = label_text

--- a/app/views/estimates/_check_answers_table.html.slim
+++ b/app/views/estimates/_check_answers_table.html.slim
@@ -45,6 +45,10 @@
                     label_text: t("estimates.check_answers.#{field.label}"),
                     value_text: field.value || t("generic.not_applicable"),
                     disputed_asset: field.disputed?
+        - when "percentage"
+          = render "check_answer",
+                    label_text: t("estimates.check_answers.#{field.label}"),
+                    value_text: (field.value ? "#{field.value}%" : t("generic.not_applicable"))
         - when "no_or_number"
           = render "check_answer",
                     label_text: t("estimates.check_answers.#{field.label}"),

--- a/spec/views/check_answers_page/client_content/property_spec.rb
+++ b/spec/views/check_answers_page/client_content/property_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "estimates/check_answers.html.slim" do
           expect(text).to include("Owns the home they live inYes")
           expect(text).to include("Estimated value£200,000.00")
           expect(text).to include("Outstanding mortgage£5,000.00")
-          expect(text).to include("Percentage share owned50")
+          expect(text).to include("Percentage share owned50%")
         end
 
         context "when is smod" do
@@ -55,7 +55,7 @@ RSpec.describe "estimates/check_answers.html.slim" do
         it "renders content" do
           expect(text).to include("Owns the home they live inYes")
           expect(text).to include("Estimated value£200,000.00")
-          expect(text).to include("Percentage share owned50")
+          expect(text).to include("Percentage share owned50%")
         end
       end
 
@@ -96,7 +96,7 @@ RSpec.describe "estimates/check_answers.html.slim" do
         it "renders content" do
           expect(text).to include("Owns other propertyYes, owned outright")
           expect(text).to include("Estimated value£100,000.00")
-          expect(text).to include("Percentage share owned100")
+          expect(text).to include("Percentage share owned100%")
         end
 
         context "when smod" do
@@ -116,7 +116,7 @@ RSpec.describe "estimates/check_answers.html.slim" do
           expect(text).to include("Owns other propertyYes, with a mortgage or loan")
           expect(text).to include("Estimated value£100,000.00")
           expect(text).to include("Outstanding mortgage£2,000.00")
-          expect(text).to include("Percentage share owned100")
+          expect(text).to include("Percentage share owned100%")
         end
       end
     end

--- a/spec/views/check_answers_page/partner_content/property_spec.rb
+++ b/spec/views/check_answers_page/partner_content/property_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "estimates/check_answers.html.slim" do
         it "renders content" do
           expect(text).to include("Owns other propertyYes, owned outright")
           expect(text).to include("Estimated value£100,000.00")
-          expect(text).to include("Percentage share owned100")
+          expect(text).to include("Percentage share owned100%")
         end
       end
 
@@ -45,7 +45,7 @@ RSpec.describe "estimates/check_answers.html.slim" do
           expect(text).to include("Owns other propertyYes, with a mortgage or loan")
           expect(text).to include("Estimated value£100,000.00")
           expect(text).to include("Outstanding mortgage£2,000.00")
-          expect(text).to include("Percentage share owned100")
+          expect(text).to include("Percentage share owned100%")
         end
       end
     end


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-1006)

## What changed and why

Percentages on check answers page now have a `%` suffix

## Guidance to review

<!-- anything useful to let the reviewer know? -->

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
