### PR TITLE
EL-999: e2e-ify all remaining end_to_end specs

### DIFF
--- a/spec/end_to_end/self_employed_spec.rb
+++ b/spec/end_to_end/self_employed_spec.rb
@@ -153,7 +153,7 @@ RSpec.describe "Self-employed flow", :self_employed_flag, type: :feature do
     context "when completing an employed check" do
       include_context "with a check containing employment data"
 
-      it "sends the right employment data to CFE" do
+      it "shows appropriate monthly income data on the results page" do
         click_on "Submit"
 
         expect(page).to have_content "Client's monthly income\nAll figures have been converted into a monthly amount.\nEmployment income\n£1,733.33"
@@ -166,7 +166,7 @@ RSpec.describe "Self-employed flow", :self_employed_flag, type: :feature do
     context "when completing a self-employed check" do
       include_context "with a check containing self-employment data"
 
-      it "sends the right self-employment data to CFE" do
+      it "shows appropriate monthly income data on the results page" do
         click_on "Submit"
 
         expect(page).to have_content "Client's monthly income\nAll figures have been converted into a monthly amount.\nEmployment income\n£758.33"
@@ -179,7 +179,7 @@ RSpec.describe "Self-employed flow", :self_employed_flag, type: :feature do
     context "when completing a partner-employed check" do
       include_context "with a check containing partner employment data"
 
-      it "sends the right partner employment data to CFE" do
+      it "shows appropriate monthly income data on the results page" do
         click_on "Submit"
 
         expect(page).to have_content "Partner's monthly income\nAll figures have been converted into a monthly amount.\nEmployment income\n£1,250.00"

--- a/spec/end_to_end/self_employed_spec.rb
+++ b/spec/end_to_end/self_employed_spec.rb
@@ -1,109 +1,192 @@
 require "rails_helper"
 
-RSpec.describe "Self-employed flow", :self_employed_flag, type: :feature do
-  let(:fixed_arbitrary_date) { Date.new(2023, 2, 15) }
-
-  before { travel_to fixed_arbitrary_date }
-
-  it "sends the right employment data to CFE" do
-    stub = stub_request(:post, %r{assessments\z}).with { |request|
-      parsed = JSON.parse(request.body)
-
-      expect(parsed["employment_details"]).to eq(
-        [
-          {
-            "income" => {
-              "benefits_in_kind" => 0,
-              "frequency" => "weekly",
-              "gross" => 1.0,
-              "national_insurance" => -0.0,
-              "tax" => -0.0,
-              "receiving_only_statutory_sick_or_maternity_pay" => false,
-            },
-          },
-        ],
-      )
-    }.to_return(
-      body: FactoryBot.build(:api_result, eligible: "eligible").to_json,
-      headers: { "Content-Type" => "application/json" },
-    )
-
+RSpec.shared_context "with a check containing employment data" do
+  before do
+    choices = {
+      frequency: "Every week",
+      gross: "400",
+      tax: "50",
+      ni: "20",
+    }
     start_assessment
     fill_in_forms_until(:employment_status)
     fill_in_employment_status_screen(choice: "Employed or self-employed")
-    fill_in_income_screen
+    fill_in_income_screen(choices)
     fill_in_forms_until(:check_answers)
-    click_on "Submit"
-
-    expect(stub).to have_been_requested
   end
+end
 
-  it "sends the right self-employment data to CFE" do
-    stub = stub_request(:post, %r{assessments\z}).with { |request|
-      parsed = JSON.parse(request.body)
-
-      expect(parsed["self_employment_details"]).to eq(
-        [
-          {
-            "income" => {
-              "frequency" => "weekly",
-              "gross" => 1.0,
-              "national_insurance" => -0.0,
-              "tax" => -0.0,
-            },
-          },
-        ],
-      )
-    }.to_return(
-      body: FactoryBot.build(:api_result, eligible: "eligible").to_json,
-      headers: { "Content-Type" => "application/json" },
-    )
-
-    stub_request(:get, %r{state_benefit_type\z}).to_return(
-      body: [].to_json,
-      headers: { "Content-Type" => "application/json" },
-    )
-
+RSpec.shared_context "with a check containing self-employment data" do
+  before do
+    choices = {
+      type: "Self-employment income",
+      frequency: "Every 2 weeks",
+      gross: "350",
+      tax: "20",
+      ni: "10",
+    }
     start_assessment
     fill_in_forms_until(:employment_status)
     fill_in_employment_status_screen(choice: "Employed or self-employed")
-    fill_in_income_screen({ type: "Self-employment income" })
+    fill_in_income_screen(choices)
     fill_in_forms_until(:check_answers)
-    click_on "Submit"
-
-    expect(stub).to have_been_requested
   end
+end
 
-  it "sends the right partner employment data to CFE" do
-    stub = stub_request(:post, %r{assessments\z}).with { |request|
-      parsed = JSON.parse(request.body)
-
-      expect(parsed["partner"]["self_employment_details"]).to eq(
-        [
-          {
-            "income" => {
-              "frequency" => "weekly",
-              "gross" => 1.0,
-              "national_insurance" => -0.0,
-              "tax" => -0.0,
-            },
-          },
-        ],
-      )
-    }.to_return(
-      body: FactoryBot.build(:api_result, eligible: "eligible").to_json,
-      headers: { "Content-Type" => "application/json" },
-    )
-
+RSpec.shared_context "with a check containing partner employment data" do
+  before do
+    choices = {
+      type: "Self-employment income",
+      frequency: "Every month",
+      gross: "1250",
+      tax: "100",
+      ni: "67",
+    }
     start_assessment
     fill_in_forms_until(:applicant)
     fill_in_applicant_screen(partner: "Yes")
     fill_in_forms_until(:partner_employment_status)
     fill_in_partner_employment_status_screen(choice: "Employed or self-employed")
-    fill_in_partner_income_screen({ type: "Self-employment income" })
+    fill_in_partner_income_screen(choices)
     fill_in_forms_until(:check_answers)
-    click_on "Submit"
+  end
+end
 
-    expect(stub).to have_been_requested
+RSpec.describe "Self-employed flow", :self_employed_flag, type: :feature do
+  let(:fixed_arbitrary_date) { Date.new(2023, 2, 15) }
+
+  before { travel_to fixed_arbitrary_date }
+
+  context "when completing an employed check" do
+    include_context "with a check containing employment data"
+
+    it "sends the right employment data to CFE" do
+      stub = stub_request(:post, %r{assessments\z}).with { |request|
+        parsed = JSON.parse(request.body)
+
+        expect(parsed["employment_details"]).to eq(
+          [
+            {
+              "income" => {
+                "benefits_in_kind" => 0,
+                "frequency" => "weekly",
+                "gross" => 400.0,
+                "national_insurance" => -20.0,
+                "tax" => -50.0,
+                "receiving_only_statutory_sick_or_maternity_pay" => false,
+              },
+            },
+          ],
+        )
+      }.to_return(
+        body: FactoryBot.build(:api_result, eligible: "eligible").to_json,
+        headers: { "Content-Type" => "application/json" },
+      )
+
+      click_on "Submit"
+
+      expect(stub).to have_been_requested
+    end
+  end
+
+  context "when completing a self-employed check" do
+    include_context "with a check containing self-employment data"
+
+    it "sends the right self-employment data to CFE" do
+      stub = stub_request(:post, %r{assessments\z}).with { |request|
+        parsed = JSON.parse(request.body)
+
+        expect(parsed["self_employment_details"]).to eq(
+          [
+            {
+              "income" => {
+                "frequency" => "two_weekly",
+                "gross" => 350.0,
+                "national_insurance" => -10.0,
+                "tax" => -20.0,
+              },
+            },
+          ],
+        )
+      }.to_return(
+        body: FactoryBot.build(:api_result, eligible: "eligible").to_json,
+        headers: { "Content-Type" => "application/json" },
+      )
+
+      click_on "Submit"
+
+      expect(stub).to have_been_requested
+    end
+  end
+
+  context "when completing a partner-employed check" do
+    include_context "with a check containing partner employment data"
+
+    it "sends the right partner employment data to CFE" do
+      stub = stub_request(:post, %r{assessments\z}).with { |request|
+        parsed = JSON.parse(request.body)
+
+        expect(parsed["partner"]["self_employment_details"]).to eq(
+          [
+            {
+              "income" => {
+                "frequency" => "monthly",
+                "gross" => 1250.0,
+                "national_insurance" => -67.0,
+                "tax" => -100.0,
+              },
+            },
+          ],
+        )
+      }.to_return(
+        body: FactoryBot.build(:api_result, eligible: "eligible").to_json,
+        headers: { "Content-Type" => "application/json" },
+      )
+
+      click_on "Submit"
+
+      expect(stub).to have_been_requested
+    end
+  end
+
+  context "when interacting with the CFE API", :end2end do
+    context "when completing an employed check" do
+      include_context "with a check containing employment data"
+
+      it "sends the right employment data to CFE" do
+        click_on "Submit"
+
+        expect(page).to have_content "Client's monthly income\nAll figures have been converted into a monthly amount.\nEmployment income\n£1,733.33"
+        expect(page).to have_content "Income tax\n£216.67"
+        expect(page).to have_content "National Insurance\n£86.67"
+        expect(page).to have_content "Employment expenses\nA fixed allowance if your client gets a salary or wage\n£45.00\n"
+      end
+    end
+
+    context "when completing a self-employed check" do
+      include_context "with a check containing self-employment data"
+
+      it "sends the right self-employment data to CFE" do
+        click_on "Submit"
+
+        expect(page).to have_content "Client's monthly income\nAll figures have been converted into a monthly amount.\nEmployment income\n£758.33"
+        expect(page).to have_content "Income tax\n£43.33"
+        expect(page).to have_content "National Insurance\n£21.67"
+        expect(page).to have_content "Employment expenses\nA fixed allowance if your client gets a salary or wage\n£0.00\n"
+      end
+    end
+
+    context "when completing a partner-employed check" do
+      include_context "with a check containing partner employment data"
+
+      it "sends the right partner employment data to CFE" do
+        click_on "Submit"
+
+        expect(page).to have_content "Partner's monthly income\nAll figures have been converted into a monthly amount.\nEmployment income\n£1,250.00"
+        expect(page).to have_content "Income tax\n£100.00"
+        expect(page).to have_content "National Insurance\n£67.00"
+        expect(page).to have_content "Employment expenses\nA fixed allowance if the partner gets a salary or wage\n£0.00\n"
+      end
+    end
   end
 end

--- a/spec/end_to_end/with_partner_spec.rb
+++ b/spec/end_to_end/with_partner_spec.rb
@@ -1,47 +1,7 @@
 require "rails_helper"
 
-RSpec.describe "Certificated check without partner", type: :feature do
-  let(:fixed_arbitrary_date) { Date.new(2023, 2, 15) }
-
-  before { travel_to fixed_arbitrary_date }
-
-  it "sends the right data to CFE for certificated work" do
-    stub = stub_request(:post, %r{assessments\z}).with { |request|
-      parsed = JSON.parse(request.body)
-
-      content = parsed["partner"]
-      expect(content["partner"]).to eq({ "date_of_birth" => "1973-02-15", "employed" => true })
-      expect(content["irregular_incomes"]).to eq([{ "income_type" => "unspecified_source", "frequency" => "quarterly", "amount" => 100.0 }])
-      expect(content.dig("employments", 0, "payments", 0)).to eq({ "gross" => 1.0,
-                                                                   "tax" => 0.0,
-                                                                   "national_insurance" => 0.0,
-                                                                   "client_id" => "id-0",
-                                                                   "date" => "2023-02-15",
-                                                                   "benefits_in_kind" => 0,
-                                                                   "net_employment_income" => 1.0 })
-      expect(content["regular_transactions"]).to eq(
-        [{ "operation" => "credit", "category" => "friends_or_family", "frequency" => "weekly", "amount" => 200.0 }],
-      )
-      expect(content["state_benefits"].length).to eq 1
-      expect(content["capitals"]).to eq({
-        "bank_accounts" => [], "non_liquid_capital" => [{ "value" => 700.0, "description" => "Non Liquid Asset", "subject_matter_of_dispute" => false }]
-      })
-      expect(content["additional_properties"]).to eq([{
-        "outstanding_mortgage" => 1.0,
-        "percentage_owned" => 1,
-        "shared_with_housing_assoc" => false,
-        "value" => 1.0,
-      }])
-    }.to_return(
-      body: FactoryBot.build(:api_result, eligible: "eligible").to_json,
-      headers: { "Content-Type" => "application/json" },
-    )
-
-    stub_request(:get, %r{state_benefit_type\z}).to_return(
-      body: [].to_json,
-      headers: { "Content-Type" => "application/json" },
-    )
-
+RSpec.shared_context "with partner data" do
+  before do
     start_assessment
     fill_in_forms_until(:applicant)
     fill_in_applicant_screen(partner: "Yes")
@@ -61,8 +21,75 @@ RSpec.describe "Certificated check without partner", type: :feature do
     fill_in_additional_property_screen
     fill_in_partner_additional_property_screen(choice: "Yes, with a mortgage or loan")
     fill_in_partner_additional_property_details_screen
-    click_on "Submit"
+  end
+end
 
-    expect(stub).to have_been_requested
+RSpec.describe "Certificated check with partner", type: :feature do
+  context "when the client has a partner" do
+    let(:fixed_arbitrary_date) { Date.new(2023, 2, 15) }
+
+    before do
+      travel_to fixed_arbitrary_date
+      stub_request(:get, %r{state_benefit_type\z}).to_return(
+        body: [].to_json,
+        headers: { "Content-Type" => "application/json" },
+      )
+    end
+
+    include_context "with partner data"
+
+    it "sends the right data to CFE for certificated work" do
+      stub = stub_request(:post, %r{assessments\z}).with { |request|
+        parsed = JSON.parse(request.body)
+
+        content = parsed["partner"]
+        expect(content["partner"]).to eq({ "date_of_birth" => "1973-02-15", "employed" => true })
+        expect(content["irregular_incomes"]).to eq([{ "income_type" => "unspecified_source", "frequency" => "quarterly", "amount" => 100.0 }])
+        expect(content.dig("employments", 0, "payments", 0)).to eq({ "gross" => 1.0,
+                                                                     "tax" => 0.0,
+                                                                     "national_insurance" => 0.0,
+                                                                     "client_id" => "id-0",
+                                                                     "date" => "2023-02-15",
+                                                                     "benefits_in_kind" => 0,
+                                                                     "net_employment_income" => 1.0 })
+        expect(content["regular_transactions"]).to eq(
+          [{ "operation" => "credit", "category" => "friends_or_family", "frequency" => "weekly", "amount" => 200.0 }],
+        )
+        expect(content["state_benefits"].length).to eq 1
+        expect(content["capitals"]).to eq({
+          "bank_accounts" => [], "non_liquid_capital" => [{ "value" => 700.0, "description" => "Non Liquid Asset", "subject_matter_of_dispute" => false }]
+        })
+        expect(content["additional_properties"]).to eq([{
+          "outstanding_mortgage" => 1.0,
+          "percentage_owned" => 1,
+          "shared_with_housing_assoc" => false,
+          "value" => 1.0,
+        }])
+      }.to_return(
+        body: FactoryBot.build(:api_result, eligible: "eligible").to_json,
+        headers: { "Content-Type" => "application/json" },
+      )
+
+      click_on "Submit"
+
+      expect(stub).to have_been_requested
+    end
+  end
+
+  context "when interacting with the CFE API", :end2end do
+    include_context "with partner data"
+
+    it "shows appropriate information on the results page" do
+      click_on "Submit"
+
+      expect(page).to have_content "Partner's monthly income\nAll figures have been converted into a monthly amount.\nEmployment income\n£4.33"
+      expect(page).to have_content "Benefits received\nThis does not include Housing Benefit\n£4.33"
+      expect(page).to have_content "Financial help from friends and family\n£866.67"
+      expect(page).to have_content "Other sources\n£33.33"
+      expect(page).to have_content "Partner allowance\nA fixed allowance if your client has a partner\n£211.32"
+      expect(page).to have_content "Employment expenses\nA fixed allowance if the partner gets a salary or wage\n£45.00"
+      expect(page).to have_content "Partner's additional property\nValue\n£1.00Outstanding mortgage\n-£1.00Assessed value\nPartner’s 1% share of home equity\n£0.00"
+      expect(page).to have_content "Investments and valuables\n£700.00"
+    end
   end
 end

--- a/spec/end_to_end/without_partner_spec.rb
+++ b/spec/end_to_end/without_partner_spec.rb
@@ -1,89 +1,7 @@
 require "rails_helper"
 
-RSpec.describe "Certificated check without partner", type: :feature do
-  let(:fixed_arbitrary_date) { Date.new(2023, 2, 15) }
-
-  before { travel_to fixed_arbitrary_date }
-
-  it "sends the right data to CFE for certificated work" do
-    stub = stub_request(:post, %r{assessments\z}).with { |request|
-      parsed = JSON.parse(request.body)
-
-      expect(parsed["assessment"]).to eq({
-        "submission_date" => "2023-02-15",
-        "level_of_help" => "certificated",
-      })
-      expect(parsed["proceeding_types"]).to eq([{ "ccms_code" => "SE003", "client_involvement_type" => "A" }])
-      expect(parsed["applicant"]).to eq({
-        "date_of_birth" => "1973-02-15",
-        "employed" => true,
-        "has_partner_opponent" => false,
-        "receives_qualifying_benefit" => false,
-        "receives_asylum_support" => false,
-      })
-      expect(parsed["dependants"]).to eq([
-        { "date_of_birth" => "2012-02-15",
-          "in_full_time_education" => true,
-          "relationship" => "child_relative",
-          "monthly_income" => 0,
-          "assets_value" => 0 },
-      ])
-
-      expect(parsed.dig("employment_income", 0, "payments", 0)).to eq({
-        "gross" => 1.0,
-        "tax" => 0.0,
-        "national_insurance" => 0.0,
-        "client_id" => "id-0",
-        "date" => "2023-02-15",
-        "benefits_in_kind" => 0,
-        "net_employment_income" => 1.0,
-      })
-
-      expect(parsed["irregular_incomes"]["payments"]).to eq(
-        [{ "income_type" => "student_loan", "frequency" => "annual", "amount" => 100.0 }],
-      )
-
-      expect(parsed["regular_transactions"]).to eq(
-        [
-          { "operation" => "credit", "category" => "friends_or_family", "frequency" => "weekly", "amount" => 200.0 },
-          { "operation" => "debit", "category" => "rent_or_mortgage", "frequency" => "monthly", "amount" => 100.0 },
-        ],
-      )
-
-      expect(parsed.dig("state_benefits", 0, "name")).to eq "A"
-      expect(parsed.dig("state_benefits", 0, "payments", 0)).to eq({ "date" => "2023-02-15", "amount" => 1.0, "client_id" => "" })
-
-      expect(parsed["vehicles"]).to eq([{
-        "value" => 1.0,
-        "loan_amount_outstanding" => 5.0,
-        "date_of_purchase" => "2021-02-15",
-        "in_regular_use" => false,
-        "subject_matter_of_dispute" => false,
-      }])
-      expect(parsed["capitals"]).to eq({
-        "bank_accounts" => [],
-        "non_liquid_capital" => [{ "value" => 700.0, "description" => "Non Liquid Asset", "subject_matter_of_dispute" => false }],
-      })
-
-      expect(parsed["properties"]).to eq({
-        "main_home" => {
-          "outstanding_mortgage" => 1.0,
-          "percentage_owned" => 1,
-          "shared_with_housing_assoc" => false,
-          "subject_matter_of_dispute" => false,
-          "value" => 1.0,
-        },
-      })
-    }.to_return(
-      body: FactoryBot.build(:api_result, eligible: "eligible").to_json,
-      headers: { "Content-Type" => "application/json" },
-    )
-
-    stub_request(:get, %r{state_benefit_type\z}).to_return(
-      body: [].to_json,
-      headers: { "Content-Type" => "application/json" },
-    )
-
+RSpec.shared_context "with a no-partner, non-passported certificated check" do
+  before do
     # This test explicitly asserts what screens are visited in what order
     start_assessment
     fill_in_provider_users_screen
@@ -103,8 +21,127 @@ RSpec.describe "Certificated check without partner", type: :feature do
     fill_in_property_entry_screen
     fill_in_mortgage_or_loan_payment_screen(amount: "100")
     fill_in_additional_property_screen
-    click_on "Submit"
+  end
+end
 
-    expect(stub).to have_been_requested
+RSpec.describe "Certificated check without partner", type: :feature do
+  context "when stubbing the CFE API" do
+    let(:fixed_arbitrary_date) { Date.new(2023, 2, 15) }
+
+    before do
+      travel_to fixed_arbitrary_date
+      stub_request(:get, %r{state_benefit_type\z}).to_return(
+        body: [].to_json,
+        headers: { "Content-Type" => "application/json" },
+      )
+    end
+
+    include_context "with a no-partner, non-passported certificated check"
+
+    it "sends the right data to CFE for certificated work" do
+      stub = stub_request(:post, %r{assessments\z}).with { |request|
+        parsed = JSON.parse(request.body)
+
+        expect(parsed["assessment"]).to eq({
+          "submission_date" => "2023-02-15",
+          "level_of_help" => "certificated",
+        })
+        expect(parsed["proceeding_types"]).to eq([{ "ccms_code" => "SE003", "client_involvement_type" => "A" }])
+        expect(parsed["applicant"]).to eq({
+          "date_of_birth" => "1973-02-15",
+          "employed" => true,
+          "has_partner_opponent" => false,
+          "receives_qualifying_benefit" => false,
+          "receives_asylum_support" => false,
+        })
+        expect(parsed["dependants"]).to eq([
+          { "date_of_birth" => "2012-02-15",
+            "in_full_time_education" => true,
+            "relationship" => "child_relative",
+            "monthly_income" => 0,
+            "assets_value" => 0 },
+        ])
+
+        expect(parsed.dig("employment_income", 0, "payments", 0)).to eq({
+          "gross" => 1.0,
+          "tax" => 0.0,
+          "national_insurance" => 0.0,
+          "client_id" => "id-0",
+          "date" => "2023-02-15",
+          "benefits_in_kind" => 0,
+          "net_employment_income" => 1.0,
+        })
+
+        expect(parsed["irregular_incomes"]["payments"]).to eq(
+          [{ "income_type" => "student_loan", "frequency" => "annual", "amount" => 100.0 }],
+        )
+
+        expect(parsed["regular_transactions"]).to eq(
+          [
+            { "operation" => "credit", "category" => "friends_or_family", "frequency" => "weekly", "amount" => 200.0 },
+            { "operation" => "debit", "category" => "rent_or_mortgage", "frequency" => "monthly", "amount" => 100.0 },
+          ],
+        )
+
+        expect(parsed.dig("state_benefits", 0, "name")).to eq "A"
+        expect(parsed.dig("state_benefits", 0, "payments", 0)).to eq({ "date" => "2023-02-15", "amount" => 1.0, "client_id" => "" })
+
+        expect(parsed["vehicles"]).to eq([{
+          "value" => 1.0,
+          "loan_amount_outstanding" => 5.0,
+          "date_of_purchase" => "2021-02-15",
+          "in_regular_use" => false,
+          "subject_matter_of_dispute" => false,
+        }])
+        expect(parsed["capitals"]).to eq({
+          "bank_accounts" => [],
+          "non_liquid_capital" => [{ "value" => 700.0, "description" => "Non Liquid Asset", "subject_matter_of_dispute" => false }],
+        })
+
+        expect(parsed["properties"]).to eq({
+          "main_home" => {
+            "outstanding_mortgage" => 1.0,
+            "percentage_owned" => 1,
+            "shared_with_housing_assoc" => false,
+            "subject_matter_of_dispute" => false,
+            "value" => 1.0,
+          },
+        })
+      }.to_return(
+        body: FactoryBot.build(:api_result, eligible: "eligible").to_json,
+        headers: { "Content-Type" => "application/json" },
+      )
+
+      click_on "Submit"
+
+      expect(stub).to have_been_requested
+    end
+  end
+
+  context "when interacting with the CFE API", :end2end do
+    include_context "with a no-partner, non-passported certificated check"
+
+    it "shows appropriate content on the results screen" do
+      click_on "Submit"
+
+      ["Your client is likely to qualify for civil legal aid",
+       "We estimate they will have to pay towards the costs of their case:\n£31.07 per month from their disposable income£0.00 lump sum payment from their disposable capital",
+       "Employment income\n£4.33",
+       "Benefits received\nThis does not include Housing Benefit\n£4.33",
+       "Financial help from friends and family\n£866.67",
+       "Student finance\n£8.33",
+       "Total monthly income£883.66",
+       "Employment expenses\nA fixed allowance if your client gets a salary or wage\n£45.00",
+       "Housing costs minus any Housing Benefit payments the household gets\n£100.00",
+       "Dependants allowance\nA fixed allowance deducted for each dependant in the household\n£338.90",
+       "Total monthly outgoings£483.90",
+       "Assessed disposable monthly income\nTotal monthly income minus total monthly outgoings\n£399.76",
+       "Home client lives in\nHome worth\n£1.00Outstanding mortgage\n-£1.001% share of home equity£0.00Assessed value£0.00",
+       "Vehicle 1\nValue£1.00Assessed value£1.00",
+       "Investments and valuables\n£700.00Total capital\n£701.00",
+       "Total assessed disposable capital£701.00"].each do |line|
+        expect(page).to have_content line
+      end
+    end
   end
 end

--- a/spec/end_to_end/without_partner_spec.rb
+++ b/spec/end_to_end/without_partner_spec.rb
@@ -142,6 +142,8 @@ RSpec.describe "Certificated check without partner", type: :feature do
        "Total assessed disposable capital£701.00"].each do |line|
         expect(page).to have_content line
       end
+
+      expect(page).not_to have_content "Partner"
     end
   end
 end


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-999)

## What changed and why

Of our 'end_to_end' specs, that fill in forms and assert expectations about the CFE payload, only some had been converted to "dual-use" specs that also send the payload to a CFE instance and assert expectations about the results page. This PR updates the rest of them to dual use.

## Guidance to review

<!-- anything useful to let the reviewer know? -->

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
