### PR TITLE
EL-986 make pdf titles single blocks

### DIFF
--- a/app/assets/stylesheets/print.scss
+++ b/app/assets/stylesheets/print.scss
@@ -33,3 +33,9 @@
                               // regardless of class-based button styles
   }
 }
+// Grover/pupetteer has a bug https://github.com/puppeteer/puppeteer/issues/4125
+// this ensures that the bug does not cause the titles in H1 and H2 elements to
+// split on the characters 'fi'
+.no-ligatures{
+  font-variant-ligatures: none;
+}

--- a/app/services/pdf_service.rb
+++ b/app/services/pdf_service.rb
@@ -9,6 +9,10 @@ class PdfService
     },
     prefer_css_page_size: true,
     print_background: true,
+    viewport: {
+      width: 2400,
+      height: 4800,
+    },
     emulate_media: "screen",
     launch_args: ["--font-render-hinting=medium", "--no-sandbox", "--force-renderer-accessibility"],
     execute_script: "document.querySelectorAll('button').forEach(el => el.style.display = 'none')",

--- a/app/views/estimates/print.html.slim
+++ b/app/views/estimates/print.html.slim
@@ -3,7 +3,7 @@
     = t("estimates.show.not_likely_to_qualify")
   - else
     = t("estimates.show.likely_to_qualify")
-.govuk-grid-column-full
+.govuk-grid-column-full.no-ligatures
   .gem-c-organisation-logo
     .gem-c-organisation-logo__container
       = pdf_friendly_logo(@is_pdf)
@@ -12,7 +12,7 @@
 
   button.govuk-button.govuk-button--secondary data-module="govuk-button" data-trigger="print" = t(".print_this_page")
 
-  = render "shared/heading", header_text: t("service.name")
+  h2.govuk-heading-l = t("service.name")
   = render "result_panel_content"
 
   - if @model.level_of_help == "certificated"


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-986)
as covered in the comments, the problem is related to ligatures (@exonian I believe you called this as a potential problem early on, bit I evidently missed that). The css fix to the print page prevents the split on `fi `character pairs

removed the partial being used to display the service name as a H1 and added a H2 directly to the print page. 

as per:
https://usability.yale.edu/web-accessibility/articles/headings
https://www.w3.org/WAI/tutorials/page-structure/headings/#main-heading-after-navigation
 there is no problem with a H2 appearing before a H1 and the H1 should be the most important part, which for us is the result.

The issue with the H2 being split  (1.4.1) cannot be exactly replicated. The fix for 1.3.1 also prevents splits on this H2 but the PDF splits anything that crosses more than 1 line. For spans this isn't really an issue but for headings this will result in each line being announced as a heading. The fix for this in this case is to prevent wrapping. It doesnt cause any issues with the rest of the display, although the heading looks slightly smaller on the page.

## Guidance to review

<!-- anything useful to let the reviewer know? -->

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
