### PR TITLE
EL-1032: Get local run coverage up to 100%

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -92,7 +92,6 @@ group :test do
   gem "selenium-webdriver"
   gem "webdrivers"
   gem "capybara-selenium"
-  gem "vcr", require: false
   gem "webmock", require: false
   gem "axe-core-rspec"
   gem "rack_session_access"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -429,7 +429,6 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.4.2)
-    vcr (6.2.0)
     view_component (3.0.0)
       activesupport (>= 5.2.0, < 8.0)
       concurrent-ruby (~> 1.0)
@@ -514,7 +513,6 @@ DEPENDENCIES
   slim-rails
   slim_lint
   tzinfo-data
-  vcr
   web-console
   webdrivers
   webmock

--- a/spec/features/help_spec.rb
+++ b/spec/features/help_spec.rb
@@ -1,0 +1,9 @@
+require "rails_helper"
+
+RSpec.describe "Help page", :public_beta_flag do
+  scenario "I can view the help page" do
+    visit root_path
+    click_on "Help"
+    expect(page).to have_current_path "/help"
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -95,6 +95,12 @@ RSpec.configure do |config|
     ENV["SELF_EMPLOYED_FEATURE_FLAG"] = "disabled"
   end
 
+  config.around(:each, :public_beta_flag) do |example|
+    ENV["PUBLIC_BETA_FEATURE_FLAG"] = "enabled"
+    example.run
+    ENV["PUBLIC_BETA_FEATURE_FLAG"] = "disabled"
+  end
+
   config.before(:suite) do
     DatabaseCleaner.clean_with :truncation
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -107,38 +107,3 @@ RSpec.configure do |config|
   #   # as the one that triggered the failure.
   #   Kernel.srand config.seed
 end
-
-require "vcr"
-
-ACCEPT_HEADERS = %w[Accept].freeze
-
-# RECORD_MODES are :once (default), :none, :new_episodes, :all
-record_mode = ENV["VCR_RECORD_MODE"] ? ENV["VCR_RECORD_MODE"].to_sym : :once
-
-VCR.configure do |config|
-  config.cassette_library_dir = "spec/fixtures/vcr_cassettes"
-  # using this higher-level hook allows WebMock to write-out stub calls when not in VCR-mode
-  config.hook_into :faraday
-  # hook the :vcr tag into RSpec flows
-  config.configure_rspec_metadata!
-  # This allows WebMock to kick in when VCR is set false
-  config.allow_http_connections_when_no_cassette = true
-
-  # CFE version info is in the accept header - so if the accept header is different, it is a different request
-  config.register_request_matcher :accept_headers_with_version do |r1, r2|
-    r1_headers = r1.headers.select { |k, _| ACCEPT_HEADERS.include?(k) }
-    r2_headers = r2.headers.select { |k, _| ACCEPT_HEADERS.include?(k) }
-
-    r1_headers == r2_headers
-  end
-
-  config.default_cassette_options = {
-    record: record_mode,
-    match_requests_on: %i[
-      method
-      uri
-      body
-      accept_headers_with_version
-    ],
-  }
-end


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-1032)

## What changed and why

In some (but not all) environments, HelpsController isn't getting loaded by rspec, leading to a simplecov failure. This basic spec ensures the controller gets loaded.

Also, we haven't used VCR in months, so gem and its config are removed.

## Guidance to review

<!-- anything useful to let the reviewer know? -->

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
