### PR TITLE
EL-1030: The liveness check checks the database is accessible

### DIFF
--- a/app/controllers/status_controller.rb
+++ b/app/controllers/status_controller.rb
@@ -1,10 +1,16 @@
 class StatusController < ApplicationController
+  # This is used by the liveness check, used to see if a pod needs replacing
   def index
-    render json: { alive: true }
+    if HealthCheckService.call(check_cfe: false)
+      render json: { alive: true }
+    else
+      render json: { alive: false }, status: :service_unavailable
+    end
   end
 
+  # This is used by the readiness check, used to see if a pod is ready to start receiving traffic
   def health
-    if HealthCheckService.call
+    if HealthCheckService.call(check_cfe: true)
       render json: { healthy: true }
     else
       render json: { healthy: false }, status: :service_unavailable

--- a/app/services/health_check_service.rb
+++ b/app/services/health_check_service.rb
@@ -1,6 +1,8 @@
 class HealthCheckService
   def self.call(check_cfe:)
-    database_healthy? && short_term_persistence_healthy? && (!check_cfe || cfe_healthy?)
+    return false if check_cfe && !cfe_healthy?
+
+    database_healthy? && short_term_persistence_healthy?
   rescue StandardError
     false
   end

--- a/app/services/health_check_service.rb
+++ b/app/services/health_check_service.rb
@@ -1,6 +1,6 @@
 class HealthCheckService
-  def self.call
-    database_healthy? && short_term_persistence_healthy? && cfe_healthy?
+  def self.call(check_cfe:)
+    database_healthy? && short_term_persistence_healthy? && (!check_cfe || cfe_healthy?)
   rescue StandardError
     false
   end

--- a/spec/requests/statuses_controller_spec.rb
+++ b/spec/requests/statuses_controller_spec.rb
@@ -18,30 +18,35 @@ RSpec.describe "status requests" do
   end
 
   describe "GET /health-including-dependents" do
-    it "is successful and alive returns true by default" do
-      stub_request(:get, %r{healthcheck\z})
+    context "when CFE is healthy" do
+      before do
+        stub_request(:get, %r{healthcheck\z})
          .to_return(status: 200, body: { checks: { database: true } }.to_json, headers: { "Content-Type" => "application/json" })
-      get("/health-including-dependents")
-      expect(response).to be_successful
-      expect(response_json).to eq("healthy" => true)
-    end
+      end
 
-    it "returns false if there is a problem reading from the database" do
-      allow(AnalyticsEvent).to receive(:count).and_raise(PG::UndefinedTable)
-      get("/health-including-dependents")
-      expect(response).not_to be_successful
-    end
+      it "is successful and alive returns true by default" do
+        get("/health-including-dependents")
+        expect(response).to be_successful
+        expect(response_json).to eq("healthy" => true)
+      end
 
-    it "returns false if there is a problem writing to the cache" do
-      allow(Rails.cache).to receive(:write).and_return(false)
-      get("/health-including-dependents")
-      expect(response).not_to be_successful
-    end
+      it "returns false if there is a problem reading from the database" do
+        allow(AnalyticsEvent).to receive(:count).and_raise(PG::UndefinedTable)
+        get("/health-including-dependents")
+        expect(response).not_to be_successful
+      end
 
-    it "returns false if there is a problem reading from the cache" do
-      allow(Rails.cache).to receive(:read).and_return(nil)
-      get("/health-including-dependents")
-      expect(response).not_to be_successful
+      it "returns false if there is a problem writing to the cache" do
+        allow(Rails.cache).to receive(:write).and_return(false)
+        get("/health-including-dependents")
+        expect(response).not_to be_successful
+      end
+
+      it "returns false if there is a problem reading from the cache" do
+        allow(Rails.cache).to receive(:read).and_return(nil)
+        get("/health-including-dependents")
+        expect(response).not_to be_successful
+      end
     end
 
     it "returns false if there is a problem reported by CFE" do

--- a/spec/requests/statuses_controller_spec.rb
+++ b/spec/requests/statuses_controller_spec.rb
@@ -9,6 +9,12 @@ RSpec.describe "status requests" do
       expect(response).to be_successful
       expect(response_json).to eq("alive" => true)
     end
+
+    it "returns false if there is a problem reading from the database" do
+      allow(AnalyticsEvent).to receive(:count).and_raise(PG::UndefinedTable)
+      get("/status")
+      expect(response).not_to be_successful
+    end
   end
 
   describe "GET /health-including-dependents" do


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-1030)

## What changed and why

This way, for UAT branches, if the database pod gets cycled and the schema gets lost, the Rails pods will stop being 'live' and new pods will be brought online, which will cause migrations to run and the schema to be re-built.

## Guidance to review

<!-- anything useful to let the reviewer know? -->

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
