### PR TITLE
EL-1022: Redirect to primary host system

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -52,4 +52,10 @@ private
   def force_setting_of_session_cookie
     session["arbitrary_key"] ||= ""
   end
+
+  def redirect_to_primary_host
+    return if ENV["PRIMARY_HOST"].blank? || ENV["PRIMARY_HOST"] == request.host
+
+    redirect_to [request.protocol, ENV["PRIMARY_HOST"], request.fullpath].join, allow_other_host: true
+  end
 end

--- a/app/controllers/estimates_controller.rb
+++ b/app/controllers/estimates_controller.rb
@@ -1,4 +1,5 @@
 class EstimatesController < ApplicationController
+  before_action :redirect_to_primary_host, only: :new
   before_action :load_check, only: %i[check_answers show print download]
 
   def new

--- a/app/controllers/start_controller.rb
+++ b/app/controllers/start_controller.rb
@@ -1,4 +1,5 @@
 class StartController < ApplicationController
+  before_action :redirect_to_primary_host, only: :index
   before_action :track_page_view, only: :index
 
   def index; end

--- a/helm_deploy/laa-estimate-eligibility/templates/_envs.tpl
+++ b/helm_deploy/laa-estimate-eligibility/templates/_envs.tpl
@@ -119,5 +119,7 @@ env:
         key: feature-flags-password
   - name: CSP_REPORT_ENDPOINT
     value: {{ .Values.sentry.cspReportEndpoint }}
+  - name: PRIMARY_HOST
+    value: {{ .Values.sentry.app.primaryHost }}
 
 {{- end }}

--- a/helm_deploy/laa-estimate-eligibility/templates/_envs.tpl
+++ b/helm_deploy/laa-estimate-eligibility/templates/_envs.tpl
@@ -120,6 +120,6 @@ env:
   - name: CSP_REPORT_ENDPOINT
     value: {{ .Values.sentry.cspReportEndpoint }}
   - name: PRIMARY_HOST
-    value: {{ .Values.sentry.app.primaryHost }}
+    value: {{ .Values.app.primaryHost }}
 
 {{- end }}

--- a/helm_deploy/laa-estimate-eligibility/values/production.yaml
+++ b/helm_deploy/laa-estimate-eligibility/values/production.yaml
@@ -73,3 +73,6 @@ geckoboard:
 sentry:
   # Despite looking very secret-y, the key here is _not_ a secret, as it will appear in every HTTP response header
   cspReportEndpoint: https://o345774.ingest.sentry.io/api/4504177640275968/security/?sentry_key=217c7d14dd2e4cfa8dc62924a1bbd237
+
+app:
+  primaryHost: ""

--- a/helm_deploy/laa-estimate-eligibility/values/staging.yaml
+++ b/helm_deploy/laa-estimate-eligibility/values/staging.yaml
@@ -73,3 +73,6 @@ geckoboard:
 sentry:
   # Despite looking very secret-y, the key here is _not_ a secret, as it will appear in every HTTP response header
   cspReportEndpoint: https://o345774.ingest.sentry.io/api/6763263/security/?sentry_key=fda2f0cddce3417c87e4df62f3611e76
+
+app:
+  primaryHost: ""

--- a/helm_deploy/laa-estimate-eligibility/values/uat.yaml
+++ b/helm_deploy/laa-estimate-eligibility/values/uat.yaml
@@ -98,3 +98,7 @@ geckoboard:
 sentry:
   # Despite looking very secret-y, the key here is _not_ a secret, as it will appear in every HTTP response header
   cspReportEndpoint: https://o345774.ingest.sentry.io/api/6747538/security/?sentry_key=53f41c70bd59430cbf0855fd6f79cf86
+
+app:
+  # TODO: Remove this before merging EL-1022. This is purely to aid UAT
+  primaryHost: main-check-client-qualifies-legal-aid-uat.cloud-platform.service.justice.gov.uk

--- a/helm_deploy/laa-estimate-eligibility/values/uat.yaml
+++ b/helm_deploy/laa-estimate-eligibility/values/uat.yaml
@@ -100,5 +100,4 @@ sentry:
   cspReportEndpoint: https://o345774.ingest.sentry.io/api/6747538/security/?sentry_key=53f41c70bd59430cbf0855fd6f79cf86
 
 app:
-  # TODO: Remove this before merging EL-1022. This is purely to aid UAT
-  primaryHost: main-check-client-qualifies-legal-aid-uat.cloud-platform.service.justice.gov.uk
+  primaryHost: ""

--- a/spec/controllers/start_controller_spec.rb
+++ b/spec/controllers/start_controller_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe StartController, type: :controller do
+  describe "GET" do
+    context "when I visit the non-primary host" do
+      around do |spec|
+        ENV["PRIMARY_HOST"] = "example2.com"
+        spec.run
+        ENV["PRIMARY_HOST"] = nil
+      end
+
+      it "redirects to the primary host" do
+        get :index, params: { foo: "bar" }
+        expect(response.headers["Location"]).to eq "http://example2.com/?foo=bar"
+      end
+    end
+
+    context "when I visit the primary host" do
+      around do |spec|
+        # 'test.host' is the default request host in controller specs
+        ENV["PRIMARY_HOST"] = "test.host"
+        spec.run
+        ENV["PRIMARY_HOST"] = nil
+      end
+
+      it "does not redirect" do
+        get :index, params: { foo: "bar" }
+        expect(response.headers["Location"]).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-1022)

## What changed and why

Make it so that the start page and the new estimate path both redirect to the primary host if one is set, so that existing checks can be completed on an old host but new ones always end up on the new one.

## Guidance to review

<!-- anything useful to let the reviewer know? -->

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
