### PR TITLE
Remove redundant webdrivers gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -90,7 +90,6 @@ group :test do
   gem "capybara"
   gem "rspec"
   gem "selenium-webdriver"
-  gem "webdrivers"
   gem "capybara-selenium"
   gem "webmock", require: false
   gem "axe-core-rspec"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -442,10 +442,6 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    webdrivers (5.2.0)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0)
     webmock (3.18.1)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -514,7 +510,6 @@ DEPENDENCIES
   slim_lint
   tzinfo-data
   web-console
-  webdrivers
   webmock
   wicked
 


### PR DESCRIPTION
This gem is [causing an issue](https://github.com/titusfortner/webdrivers/issues/247#issuecomment-1650315937) where it expects a chrome driver to be available in a place where it isn't. It's redundant, so we can safely remove it.