### PR TITLE
Turn on public beta on staging

### DIFF
--- a/helm_deploy/laa-estimate-eligibility/values/staging.yaml
+++ b/helm_deploy/laa-estimate-eligibility/values/staging.yaml
@@ -59,7 +59,7 @@ featureFlags:
   sentry: ENABLED
   selfEmployed: ENABLED
   overrides: NOT_ENABLED
-  publicBeta: NOT_ENABLED
+  publicBeta: ENABLED
   indexProduction: NOT_ENABLED
   maintenanceMode: NOT_ENABLED
   basicAuthentication: ENABLED


### PR DESCRIPTION
As we're a week out, this gives us a stable place to preview public beta.