### PR TITLE
EL-1099: Standardise numbering of "add another" sections

### DIFF
--- a/app/javascript/add-another.js
+++ b/app/javascript/add-another.js
@@ -85,7 +85,7 @@ const setUpSections = (sectionList) => {
 const setNumbering = (section, counter) => {
   const counterElement = section.querySelector('[data-add-another-role="counter"]')
   if (counterElement) {
-    counterElement.innerHTML = counterElement.dataset.addAnotherNumberFrom === "zero" ? counter : counter + 1;
+    counterElement.innerHTML = counter + 1;
   }
   section.querySelectorAll('[data-add-another-dynamic-elements]').forEach((element) => {
     element.dataset.addAnotherDynamicElements.split(",").forEach((pairString) => {

--- a/app/services/check_answers/section_lister_service.rb
+++ b/app/services/check_answers/section_lister_service.rb
@@ -80,16 +80,11 @@ module CheckAnswers
       return if field_data[:skip_unless].present? && !model.send(field_data[:skip_unless])
       return if field_data[:skip_if].present? && model.send(field_data[:skip_if])
 
-      label = if index
-                index.zero? ? "#{field_data.fetch(:attribute)}_first" : "#{field_data.fetch(:attribute)}_subsequent"
-              else
-                field_data.fetch(:attribute)
-              end
       addendum = "_partner" if @check.partner && field_data[:partner_dependant_wording]
 
       disputed = field_data[:disputed_if].present? && @check.smod_applicable? && model.send(field_data.fetch(:disputed_if))
 
-      Field.new(label: "#{table_label}_fields.#{label}#{addendum}",
+      Field.new(label: "#{table_label}_fields.#{field_data.fetch(:attribute)}#{addendum}",
                 type: field_data[:type],
                 value: model.send(field_data[:attribute]),
                 disputed?: disputed,
@@ -99,7 +94,7 @@ module CheckAnswers
 
     def build_many_fields(field_data, model, table_label)
       submodel = model.send(field_data[:model])
-      submodel.each_with_index.map { build_field(field_data[:template], _1, table_label, index: _2) }
+      submodel.each_with_index.map { build_field(field_data[:template], _1, table_label, index: _2 + 1) }
     end
 
     def section_yaml

--- a/app/views/estimate_flow/_additional_property_section.html.slim
+++ b/app/views/estimate_flow/_additional_property_section.html.slim
@@ -1,10 +1,10 @@
 - counter ||= nil
 . data-add-another-role="section" id=("section-#{counter}" if counter)
-  - if removeable
-    .add-another-heading
-      h2.govuk-heading-m
-        = t("estimate_flow.additional_property_details.additional_property")
-        span< data-add-another-role="counter" = counter
+  .add-another-heading
+    h2.govuk-heading-m
+      = t("estimate_flow.additional_property_details.additional_property")
+      span< data-add-another-role="counter" = counter
+    - if removeable
       button.govuk-button.govuk-button--secondary type="button" data-add-another-role="remove" id="remove-#{counter}" = t("generic.remove")
 
   / HOUSE VALUE

--- a/app/views/estimate_flow/_bank_account_section.html.slim
+++ b/app/views/estimate_flow/_bank_account_section.html.slim
@@ -1,10 +1,10 @@
 - counter ||= nil
 . data-add-another-role="section" id=("section-#{counter}" if counter)
-  - if removeable
-    .add-another-heading
-      h2.govuk-heading-m
-        = t("estimate_flow.assets.additional_bank_account")
-        span< data-add-another-role="counter" data-add-another-number-from="zero" = counter
+  .add-another-heading
+    h2.govuk-heading-m
+      = t("estimate_flow.assets.bank_account")
+      span< data-add-another-role="counter" = counter
+    - if removeable
       button.govuk-button.govuk-button--secondary type="button" data-add-another-role="remove" id="remove-#{counter}" = t("generic.remove")
 
   = render "shared/add_another/money_field",

--- a/app/views/estimate_flow/_benefit_section.html.slim
+++ b/app/views/estimate_flow/_benefit_section.html.slim
@@ -1,10 +1,10 @@
 - counter ||= nil
 . data-add-another-role="section" id=("section-#{counter}" if counter)
-  - if removeable
-    .add-another-heading
-      h2.govuk-heading-m
-        = t("estimate_flow.benefit_details.benefit")
-        span< data-add-another-role="counter" = counter
+  .add-another-heading
+    h2.govuk-heading-m
+      = t("estimate_flow.benefit_details.benefit")
+      span< data-add-another-role="counter" = counter
+    - if removeable
       button.govuk-button.govuk-button--secondary type="button" data-add-another-role="remove" = t("generic.remove")
 
   .govuk-form-group [role="combobox"

--- a/app/views/estimate_flow/_income_section.html.slim
+++ b/app/views/estimate_flow/_income_section.html.slim
@@ -1,10 +1,10 @@
 - counter ||= nil
 . data-add-another-role="section" id=("section-#{counter}" if counter)
-  - if removeable
-    .add-another-heading
-      h2.govuk-heading-m
-        = t("estimate_flow.income.income")
-        span< data-add-another-role="counter" = counter
+  .add-another-heading
+    h2.govuk-heading-m
+      = t("estimate_flow.income.income")
+      span< data-add-another-role="counter" = counter
+    - if removeable
       button.govuk-button.govuk-button--secondary type="button" data-add-another-role="remove" = t("generic.remove")
 
   = render "shared/add_another/radio_field",

--- a/app/views/estimate_flow/_vehicle_section.html.slim
+++ b/app/views/estimate_flow/_vehicle_section.html.slim
@@ -1,10 +1,10 @@
 - counter ||= nil
 . data-add-another-role="section" id=("section-#{counter}" if counter)
-  - if removeable
-    .add-another-heading
-      h2.govuk-heading-m
-        = t("estimate_flow.vehicles_details.vehicle")
-        span< data-add-another-role="counter" = counter
+  .add-another-heading
+    h2.govuk-heading-m
+      = t("estimate_flow.vehicles_details.vehicle")
+      span< data-add-another-role="counter" = counter
+    - if removeable
       button.govuk-button.govuk-button--secondary type="button" data-add-another-role="remove" id="remove-#{counter}" = t("generic.remove")
 
   / VEHICLE VALUE

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -770,7 +770,7 @@ en:
       income_tax: Income tax
       national_insurance: National insurance
       add: Add another employment income
-      income: Income
+      income: Employment income
       guidance:
         text: Guidance on income
       police_guidance:
@@ -1129,7 +1129,7 @@ en:
           - Enter 0 if this does not apply.
         input: Total money in account
       add_bank_account: Add another bank account
-      additional_bank_account: Additional bank account
+      bank_account: Bank account
       investments:
         label: Investments
         hints:
@@ -1486,13 +1486,11 @@ en:
         partner_maintenance_payments_value: Maintenance payments
         partner_legal_aid_payments_value: Legal aid payments
       assets_fields:
-        amount_first: Money in bank accounts
-        amount_subsequent: Additional bank account %{variable}
+        amount: Money in bank account %{variable}
         investments: Investments
         valuables: Valuable items worth £500 or more
       partner_assets_fields:
-        amount_first: Money in bank accounts
-        amount_subsequent: Additional bank account %{variable}
+        amount: Money in bank account %{variable}
         partner_investments: Investments
         partner_valuables: Valuable items worth £500 or more
       vehicle_fields:

--- a/spec/views/check_answers_page/client_content/assets_spec.rb
+++ b/spec/views/check_answers_page/client_content/assets_spec.rb
@@ -111,8 +111,8 @@ RSpec.describe "estimates/check_answers.html.slim" do
           it "renders the content correctly" do
             expect_in_text(text, [
               "Client assetsChange",
-              "Money in bank accounts£50.00",
-              "Additional bank account 1£30.00",
+              "Money in bank account 1£50.00",
+              "Money in bank account 2£30.00",
               "Investments£60.00",
               "Valuable items worth £500 or more£550.00",
             ])
@@ -122,7 +122,7 @@ RSpec.describe "estimates/check_answers.html.slim" do
             let(:savings_in_dispute) { true }
 
             it "renders content" do
-              expect(page_text_within("#money-in-bank-accounts")).to include("Disputed asset")
+              expect(page_text_within("#money-in-bank-account-1")).to include("Disputed asset")
             end
           end
         end
@@ -138,7 +138,7 @@ RSpec.describe "estimates/check_answers.html.slim" do
           it "renders content" do
             expect_in_text(text, [
               "Client assetsChange",
-              "Money in bank accounts£0.00",
+              "Money in bank account 1£0.00",
               "Investments£0.00",
               "Valuable items worth £500 or more£0.00",
             ])

--- a/spec/views/check_answers_page/partner_content/assets_spec.rb
+++ b/spec/views/check_answers_page/partner_content/assets_spec.rb
@@ -27,8 +27,8 @@ RSpec.describe "estimates/check_answers.html.slim" do
           it "renders content" do
             expect_in_text(text, [
               "Partner assetsChange",
-              "Money in bank accounts£50.00",
-              "Additional bank account 1£20.00",
+              "Money in bank account 1£50.00",
+              "Money in bank account 2£20.00",
               "Investments£60.00",
               "Valuable items worth £500 or more£550.00",
             ])
@@ -47,7 +47,7 @@ RSpec.describe "estimates/check_answers.html.slim" do
           it "renders content" do
             expect_in_text(page_text_within("#table-partner_assets"), [
               "Partner assetsChange",
-              "Money in bank accounts£0.00",
+              "Money in bank account 1£0.00",
               "Investments£0.00",
               "Valuable items worth £500 or more£0.00",
             ])


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-1099)

## What changed and why

All 'add another' sections have labels starting at 1. Remove JS logic to allow starting at a hidden zero.

## Guidance to review

<!-- anything useful to let the reviewer know? -->

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
