### PR TITLE
EL-1102: Make migration rake task more robust

### DIFF
--- a/lib/tasks/jobs/migrations.rake
+++ b/lib/tasks/jobs/migrations.rake
@@ -1,12 +1,16 @@
 namespace :db do
   namespace :migrations do
-    desc "Run db:migrate and retry if ActiveRecord::ConcurrentMigrationError encountered"
+    desc "Run db:migrate and retry if 2-pods-running-this-at-once issues encountered"
     task run_with_retry: :environment do
       attempts = 0
       begin
         Rake::Task["db:migrate"].reenable
         Rake::Task["db:migrate"].invoke
-      rescue ActiveRecord::ConcurrentMigrationError
+      # If 2 pods try to run a migration at once on the same database, a ConcurrentMigrationError may be encountered.
+      # If 2 pods try to do initial setup at once on the same database, a RecordNotUnique error may be encountered
+      # as they both try to create the schema_migrations table. RecordNotUnique could indicate an error with the
+      # migration itself. If so, this will keep failing after multiple retries so will eventually be raised here.
+      rescue ActiveRecord::ConcurrentMigrationError, ActiveRecord::RecordNotUnique
         attempts += 1
         if attempts <= 3
           sleep(5)


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-1102)

## What changed and why

Allow migrations to recover from an error that sometimes happens when 2 pods try to run them at the same time.

## Guidance to review

<!-- anything useful to let the reviewer know? -->

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
