### PR TITLE
EL-1228: Add client-side Sentry monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,13 +236,15 @@ It is also possible to manually deploy to an environment from the command line, 
 
 Secrets have been stored for each environment using `kubectl create secret`. The following secrets are currently in use:
 
-* sentry-dsn
 * notifications-api-key
 * secret-key-base
 * geckoboard-api-key
 * blazer-password
 * blazer-database-password
 * feature-flags-password
+* slack-webhook-url
+* basic-auth-password
+* google-oauth-client-secret
 
 The current values for these are available as secure notes in 1Password for each environment, should they be lost from Kubernetes.
 

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -5,8 +5,15 @@ if (sentryDsn) {
   Sentry.init({
     dsn: sentryDsn,
     integrations: [new Sentry.BrowserTracing(), new Sentry.Replay()],
-    tracesSampleRate: 1.0,
+    // All errors are captured
+    sampleRate: 1,
+    // 10% of non-erroring sessions are captured for performance monitoring
+    tracesSampleRate: 0.1,
+
+    // 10% of sessions are replayable
     replaysSessionSampleRate: 0.1,
+
+    // All erroring sessions are replayable
     replaysOnErrorSampleRate: 1.0,
   });
 }

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -7,14 +7,13 @@ if (sentryDsn) {
     integrations: [new Sentry.BrowserTracing(), new Sentry.Replay()],
     // All errors are captured
     sampleRate: 1,
-    // 10% of non-erroring sessions are captured for performance monitoring
-    tracesSampleRate: 0.1,
-
-    // 10% of sessions are replayable
-    replaysSessionSampleRate: 0.1,
-
     // All erroring sessions are replayable
     replaysOnErrorSampleRate: 1.0,
+
+    // No non-erroring sessions are captured for performance monitoring
+    tracesSampleRate: 0,
+    // No non-erroring sessions are replayable
+    replaysSessionSampleRate: 0,
   });
 }
 

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -46,5 +46,3 @@ if (!window._rails_loaded) {
 initAll();
 initResults();
 initFeedback();
-
-

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,6 +1,7 @@
 import { initAll } from "govuk-frontend";
 import initResults from "./results";
 import Rails from '@rails/ujs';
+import * as Sentry from "@sentry/browser";
 
 // NOTE: suggestions input component not yet part of GOV.UK frontend
 // https://github.com/alphagov/govuk-frontend/pull/2453
@@ -27,3 +28,14 @@ if (!window._rails_loaded) {
 initAll();
 initResults();
 initFeedback();
+
+const sentryDsn = document.querySelector("body").dataset.sentryDsn;
+if (sentryDsn) {
+  Sentry.init({
+    dsn: sentryDsn,
+    integrations: [new Sentry.BrowserTracing(), new Sentry.Replay()],
+    tracesSampleRate: 1.0,
+    replaysSessionSampleRate: 0.1,
+    replaysOnErrorSampleRate: 1.0,
+  });
+}

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,7 +1,19 @@
+import * as Sentry from "@sentry/browser";
+
+const sentryDsn = document.querySelector("body").dataset.sentryDsn;
+if (sentryDsn) {
+  Sentry.init({
+    dsn: sentryDsn,
+    integrations: [new Sentry.BrowserTracing(), new Sentry.Replay()],
+    tracesSampleRate: 1.0,
+    replaysSessionSampleRate: 0.1,
+    replaysOnErrorSampleRate: 1.0,
+  });
+}
+
 import { initAll } from "govuk-frontend";
 import initResults from "./results";
 import Rails from '@rails/ujs';
-import * as Sentry from "@sentry/browser";
 
 // NOTE: suggestions input component not yet part of GOV.UK frontend
 // https://github.com/alphagov/govuk-frontend/pull/2453
@@ -29,13 +41,4 @@ initAll();
 initResults();
 initFeedback();
 
-const sentryDsn = document.querySelector("body").dataset.sentryDsn;
-if (sentryDsn) {
-  Sentry.init({
-    dsn: sentryDsn,
-    integrations: [new Sentry.BrowserTracing(), new Sentry.Replay()],
-    tracesSampleRate: 1.0,
-    replaysSessionSampleRate: 0.1,
-    replaysOnErrorSampleRate: 1.0,
-  });
-}
+

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -29,7 +29,7 @@ html dir="ltr" lang="en-GB" class="govuk-template"
 
     = stylesheet_link_tag "application", "data-turbo-track": "reload"
     = javascript_include_tag "application", "data-turbo-track": "reload", defer: true, nonce: true
-  body class="govuk-template__body"
+  body class="govuk-template__body" data-sentry-dsn=ENV["SENTRY_CLIENT_SIDE_DSN"]
     = render "layouts/analytics_body"
     javascript [nonce=content_security_policy_nonce]:
       document.body.className = ((document.body.className) ? document.body.className + " js-enabled" : "js-enabled");

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -29,7 +29,8 @@ html dir="ltr" lang="en-GB" class="govuk-template"
 
     = stylesheet_link_tag "application", "data-turbo-track": "reload"
     = javascript_include_tag "application", "data-turbo-track": "reload", defer: true, nonce: true
-  body class="govuk-template__body" data-sentry-dsn=ENV["SENTRY_CLIENT_SIDE_DSN"]
+  body[class="govuk-template__body"
+       data-sentry-dsn=(ENV["SENTRY_CLIENT_SIDE_DSN"] if FeatureFlags.enabled?(:sentry, without_session_data: true))]
     = render "layouts/analytics_body"
     javascript [nonce=content_security_policy_nonce]:
       document.body.className = ((document.body.className) ? document.body.className + " js-enabled" : "js-enabled");

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -30,7 +30,7 @@ html dir="ltr" lang="en-GB" class="govuk-template"
     = stylesheet_link_tag "application", "data-turbo-track": "reload"
     = javascript_include_tag "application", "data-turbo-track": "reload", defer: true, nonce: true
   body[class="govuk-template__body"
-       data-sentry-dsn=(ENV["SENTRY_CLIENT_SIDE_DSN"] if FeatureFlags.enabled?(:sentry, without_session_data: true))]
+       data-sentry-dsn=(Rails.configuration.sentry_dsn if FeatureFlags.enabled?(:sentry, without_session_data: true))]
     = render "layouts/analytics_body"
     javascript [nonce=content_security_policy_nonce]:
       document.body.className = ((document.body.className) ? document.body.className + " js-enabled" : "js-enabled");

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -17,6 +17,9 @@ Rails.application.configure do
     # This is the SHA for the inline CSS used by the static service unavailable page (as it's static, it can't use a nonce)
     policy.style_src   "'sha256-77rnAjTWIfn0C+JGy/VQ5ZlAh2ZNEkgbAZfHP+ot9k0='", :self, :https, :report_sample
 
+    # Sentry creates workers from "blobs" in order to report on errors, so we allow that
+    policy.worker_src :blob
+
     # Specify URI for violation reports
     policy.report_uri(ENV["CSP_REPORT_ENDPOINT"]) if ENV["CSP_REPORT_ENDPOINT"].present?
   end

--- a/helm_deploy/laa-estimate-eligibility/templates/_envs.tpl
+++ b/helm_deploy/laa-estimate-eligibility/templates/_envs.tpl
@@ -51,6 +51,8 @@ env:
       secretKeyRef:
         name: kube-secrets
         key: sentry-dsn
+  - name: SENTRY_CLIENT_SIDE_DSN
+    value: {{ .Values.sentry.clientSideDsn }}
   - name: GOOGLE_TAG_MANAGER_ID
     value: {{ .Values.googleTagManager.containerId }}
   - name: CFE_HOST

--- a/helm_deploy/laa-estimate-eligibility/templates/_envs.tpl
+++ b/helm_deploy/laa-estimate-eligibility/templates/_envs.tpl
@@ -47,12 +47,7 @@ env:
   - name: RAILS_LOG_TO_STDOUT
     value: 'true'
   - name: SENTRY_DSN
-    valueFrom:
-      secretKeyRef:
-        name: kube-secrets
-        key: sentry-dsn
-  - name: SENTRY_CLIENT_SIDE_DSN
-    value: {{ .Values.sentry.clientSideDsn }}
+    value: {{ .Values.sentry.dsn }}
   - name: GOOGLE_TAG_MANAGER_ID
     value: {{ .Values.googleTagManager.containerId }}
   - name: CFE_HOST

--- a/helm_deploy/laa-estimate-eligibility/values/production.yaml
+++ b/helm_deploy/laa-estimate-eligibility/values/production.yaml
@@ -73,7 +73,7 @@ sentry:
   # Despite looking very secret-y, the key here is _not_ a secret, as it will appear in every HTTP response header
   cspReportEndpoint: https://o345774.ingest.sentry.io/api/4504177640275968/security/?sentry_key=217c7d14dd2e4cfa8dc62924a1bbd237
   # Similarly this is available in the page source
-  clientSideDsn: https://cd41516e32594c35ae312a4c53936956@o345774.ingest.sentry.io/4504177640275968
+  dsn: https://cd41516e32594c35ae312a4c53936956@o345774.ingest.sentry.io/4504177640275968
 
 app:
   primaryHost: "check-your-client-qualifies-for-legal-aid.service.gov.uk"

--- a/helm_deploy/laa-estimate-eligibility/values/production.yaml
+++ b/helm_deploy/laa-estimate-eligibility/values/production.yaml
@@ -72,6 +72,8 @@ geckoboard:
 sentry:
   # Despite looking very secret-y, the key here is _not_ a secret, as it will appear in every HTTP response header
   cspReportEndpoint: https://o345774.ingest.sentry.io/api/4504177640275968/security/?sentry_key=217c7d14dd2e4cfa8dc62924a1bbd237
+  # Similarly this is available in the page source
+  clientSideDsn: https://cd41516e32594c35ae312a4c53936956@o345774.ingest.sentry.io/4504177640275968
 
 app:
   primaryHost: "check-your-client-qualifies-for-legal-aid.service.gov.uk"

--- a/helm_deploy/laa-estimate-eligibility/values/staging.yaml
+++ b/helm_deploy/laa-estimate-eligibility/values/staging.yaml
@@ -72,6 +72,8 @@ geckoboard:
 sentry:
   # Despite looking very secret-y, the key here is _not_ a secret, as it will appear in every HTTP response header
   cspReportEndpoint: https://o345774.ingest.sentry.io/api/6763263/security/?sentry_key=fda2f0cddce3417c87e4df62f3611e76
+  # Similarly this is available in the page source
+  clientSideDsn: https://f55bec8a5587418e932cd4935569a06b@o345774.ingest.sentry.io/6763263
 
 app:
   primaryHost: ""

--- a/helm_deploy/laa-estimate-eligibility/values/staging.yaml
+++ b/helm_deploy/laa-estimate-eligibility/values/staging.yaml
@@ -73,7 +73,7 @@ sentry:
   # Despite looking very secret-y, the key here is _not_ a secret, as it will appear in every HTTP response header
   cspReportEndpoint: https://o345774.ingest.sentry.io/api/6763263/security/?sentry_key=fda2f0cddce3417c87e4df62f3611e76
   # Similarly this is available in the page source
-  clientSideDsn: https://f55bec8a5587418e932cd4935569a06b@o345774.ingest.sentry.io/6763263
+  dsn: https://f55bec8a5587418e932cd4935569a06b@o345774.ingest.sentry.io/6763263
 
 app:
   primaryHost: ""

--- a/helm_deploy/laa-estimate-eligibility/values/uat.yaml
+++ b/helm_deploy/laa-estimate-eligibility/values/uat.yaml
@@ -96,7 +96,7 @@ sentry:
   # Despite looking very secret-y, the key here is _not_ a secret, as it will appear in every HTTP response header
   cspReportEndpoint: https://o345774.ingest.sentry.io/api/6747538/security/?sentry_key=53f41c70bd59430cbf0855fd6f79cf86
   # Similarly this is available in the page source
-  clientSideDsn: https://04ec9fc34a2146138f8a2da2d243a718@o345774.ingest.sentry.io/6747538
+  dsn: https://04ec9fc34a2146138f8a2da2d243a718@o345774.ingest.sentry.io/6747538
 
 app:
   primaryHost: ""

--- a/helm_deploy/laa-estimate-eligibility/values/uat.yaml
+++ b/helm_deploy/laa-estimate-eligibility/values/uat.yaml
@@ -95,6 +95,8 @@ geckoboard:
 sentry:
   # Despite looking very secret-y, the key here is _not_ a secret, as it will appear in every HTTP response header
   cspReportEndpoint: https://o345774.ingest.sentry.io/api/6747538/security/?sentry_key=53f41c70bd59430cbf0855fd6f79cf86
+  # Similarly this is available in the page source
+  clientSideDsn: https://04ec9fc34a2146138f8a2da2d243a718@o345774.ingest.sentry.io/6747538
 
 app:
   primaryHost: ""

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "dependencies": {
     "@ministryofjustice/frontend": "^1.8.0",
     "@rails/ujs": "^7.1.1",
+    "@sentry/browser": "^7.73.0",
     "esbuild": "^0.19.4",
     "govuk-frontend": "^4.7.0",
     "jquery": "^3.7.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -199,6 +199,59 @@
   resolved "https://registry.yarnpkg.com/@rails/ujs/-/ujs-7.1.1.tgz#f8df96e406a2a824084b637880e57c257073cb05"
   integrity sha512-ywGwWNiqXN3Bb1BifVQTrkWEWcAGLHW3D0JNQMQeu57LsoluRzvnenNLPsmdoDPkrmSIASDXNsJiCIpUzFj8CA==
 
+"@sentry-internal/tracing@7.73.0":
+  version "7.73.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/tracing/-/tracing-7.73.0.tgz#4838f31e41d23a6041ef4520519b80f788bf1cac"
+  integrity sha512-ig3WL/Nqp8nRQ52P205NaypGKNfIl/G+cIqge9xPW6zfRb5kJdM1YParw9GSJ1SPjEZBkBORGAML0on5H2FILw==
+  dependencies:
+    "@sentry/core" "7.73.0"
+    "@sentry/types" "7.73.0"
+    "@sentry/utils" "7.73.0"
+    tslib "^2.4.1 || ^1.9.3"
+
+"@sentry/browser@^7.73.0":
+  version "7.73.0"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-7.73.0.tgz#a8eaeb50cf16ca32f0039a81719c503d7045495f"
+  integrity sha512-e301hUixcJ5+HNKCJwajFF5smF4opXEFSclyWsJuFNufv5J/1C1SDhbwG2JjBt5zzdSoKWJKT1ewR6vpICyoDw==
+  dependencies:
+    "@sentry-internal/tracing" "7.73.0"
+    "@sentry/core" "7.73.0"
+    "@sentry/replay" "7.73.0"
+    "@sentry/types" "7.73.0"
+    "@sentry/utils" "7.73.0"
+    tslib "^2.4.1 || ^1.9.3"
+
+"@sentry/core@7.73.0":
+  version "7.73.0"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.73.0.tgz#1caeeec44f42c4d58c06cc05dec39e5497b65aa3"
+  integrity sha512-9FEz4Gq848LOgVN2OxJGYuQqxv7cIVw69VlAzWHEm3njt8mjvlTq+7UiFsGRo84+59V2FQuHxzA7vVjl90WfSg==
+  dependencies:
+    "@sentry/types" "7.73.0"
+    "@sentry/utils" "7.73.0"
+    tslib "^2.4.1 || ^1.9.3"
+
+"@sentry/replay@7.73.0":
+  version "7.73.0"
+  resolved "https://registry.yarnpkg.com/@sentry/replay/-/replay-7.73.0.tgz#4e6c522bac5c12f596ef76afe15ecb3807407669"
+  integrity sha512-a8IC9SowBisLYD2IdLkXzx7gN4iVwHDJhQvLp2B8ARs1PyPjJ7gCxSMHeGrYp94V0gOXtorNYkrxvuX8ayPROA==
+  dependencies:
+    "@sentry/core" "7.73.0"
+    "@sentry/types" "7.73.0"
+    "@sentry/utils" "7.73.0"
+
+"@sentry/types@7.73.0":
+  version "7.73.0"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.73.0.tgz#6d811bbe413d319df0a592a672d6d72a94a8e716"
+  integrity sha512-/v8++bly8jW7r4cP2wswYiiVpn7eLLcqwnfPUMeCQze4zj3F3nTRIKc9BGHzU0V+fhHa3RwRC2ksqTGq1oJMDg==
+
+"@sentry/utils@7.73.0":
+  version "7.73.0"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.73.0.tgz#530cf023f7c395aa7708cd3824e5a45948449c10"
+  integrity sha512-h3ZK/qpf4k76FhJV9uiSbvMz3V/0Ovy94C+5/9UgPMVCJXFmVsdw8n/dwANJ7LupVPfYP23xFGgebDMFlK1/2w==
+  dependencies:
+    "@sentry/types" "7.73.0"
+    tslib "^2.4.1 || ^1.9.3"
+
 "@tootallnate/quickjs-emscripten@^0.23.0":
   version "0.23.0"
   resolved "https://registry.yarnpkg.com/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz#db4ecfd499a9765ab24002c3b696d02e6d32a12c"
@@ -1025,6 +1078,11 @@ tslib@^2.0.1:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.0.tgz#b295854684dbda164e181d259a22cd779dcd7bc3"
   integrity sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==
+
+"tslib@^2.4.1 || ^1.9.3":
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
+  integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
 
 unbzip2-stream@1.4.3:
   version "1.4.3"


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-1228)

## What changed and why

Put environment-specific Sentry keys in config, and use them to init Sentry client-side error reporting, adjusting our CSP to allow it.

## Guidance to review

<!-- anything useful to let the reviewer know? -->

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
