### PR TITLE
EL-1217: Dual running new UAT namespace

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -272,9 +272,24 @@ workflows:
           requires:
             - install_dependencies
       - deploy:
-          name: Deploy UAT
+          name: Deploy UAT to existing namespace
           environment: uat
           context: laa-estimate-eligibility-uat
+          requires:
+            - linters
+            - run_specs
+            - end2end_tests
+            - linters
+            - build_and_push
+          post-steps:
+            - jira/notify:
+                job_type: deployment
+                environment: UAT
+                environment_type: testing
+      - deploy:
+          name: Deploy UAT to new namespace
+          environment: ccq-uat
+          context: laa-check-client-qualifies-uat
           requires:
             - linters
             - run_specs

--- a/bin/deploy
+++ b/bin/deploy
@@ -7,7 +7,7 @@ ENVIRONMENT=$1
 
 deploy_branch() {
 # Set the deployment host, this will add the prefix of the branch name e.g el-257-deploy-with-circleci or just main
-  RELEASE_HOST="$BRANCH_RELEASE_NAME-check-client-qualifies-legal-aid-$ENVIRONMENT.cloud-platform.service.justice.gov.uk"
+  RELEASE_HOST="$BRANCH_RELEASE_NAME-$BRANCH_HOST_SUFFIX.cloud-platform.service.justice.gov.uk"
 # Set the ingress name, needs release name, namespace and -green suffix
   IDENTIFIER="$BRANCH_RELEASE_NAME-laa-estimate-eligibility-$K8S_NAMESPACE-green"
   echo "Deploying CIRCLE_SHA1: $CIRCLE_SHA1 under release name: '$BRANCH_RELEASE_NAME'..."

--- a/bin/deploy
+++ b/bin/deploy
@@ -7,15 +7,15 @@ ENVIRONMENT=$1
 
 deploy_branch() {
 # Set the deployment host, this will add the prefix of the branch name e.g el-257-deploy-with-circleci or just main
-  RELEASE_HOST="$BRANCH_RELEASE_NAME-check-client-qualifies-legal-aid-uat.cloud-platform.service.justice.gov.uk"
+  RELEASE_HOST="$BRANCH_RELEASE_NAME-check-client-qualifies-legal-aid-$ENVIRONMENT.cloud-platform.service.justice.gov.uk"
 # Set the ingress name, needs release name, namespace and -green suffix
-  IDENTIFIER="$BRANCH_RELEASE_NAME-laa-estimate-eligibility-laa-estimate-financial-eligibility-for-legal-aid-uat-green"
+  IDENTIFIER="$BRANCH_RELEASE_NAME-laa-estimate-eligibility-$K8S_NAMESPACE-green"
   echo "Deploying CIRCLE_SHA1: $CIRCLE_SHA1 under release name: '$BRANCH_RELEASE_NAME'..."
 
   helm upgrade $BRANCH_RELEASE_NAME ./helm_deploy/laa-estimate-eligibility/. \
                 --install --wait \
                 --namespace=${K8S_NAMESPACE} \
-                --values ./helm_deploy/laa-estimate-eligibility/values/uat.yaml \
+                --values ./helm_deploy/laa-estimate-eligibility/values/$ENVIRONMENT.yaml \
                 --set image.repository="$ECR_ENDPOINT" \
                 --set image.tag="branch-$CIRCLE_SHA1" \
                 --set ingress.annotations."external-dns\.alpha\.kubernetes\.io/set-identifier"="$IDENTIFIER" \

--- a/helm_deploy/laa-estimate-eligibility/templates/_envs.tpl
+++ b/helm_deploy/laa-estimate-eligibility/templates/_envs.tpl
@@ -54,11 +54,19 @@ env:
     value: {{ .Values.cfe.host }}
   - name: CFE_ENVIRONMENT_NAME
     value: {{ .Values.cfe.environment_name }}
+  {{ if .Values.use_new_namespace.enabled }}
+  - name: REDIS_URL
+    valueFrom:
+      secretKeyRef:
+        name: laa-check-client-qualifies-elasticache-instance-output
+        key: url
+  {{ else }}
   - name: REDIS_URL
     valueFrom:
       secretKeyRef:
         name: laa-estimate-financial-eligibility-elasticache-instance-output
         key: url
+  {{ end }}
   - name: SENTRY_FEATURE_FLAG
     value: {{ .Values.featureFlags.sentry }}
   - name: INDEX_PRODUCTION_FEATURE_FLAG

--- a/helm_deploy/laa-estimate-eligibility/values/ccq-uat.yaml
+++ b/helm_deploy/laa-estimate-eligibility/values/ccq-uat.yaml
@@ -1,4 +1,4 @@
-# Default values for laa-estimate-eligibility-uat.
+# Default values for laa-check-client-qualifies-uat.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
@@ -40,11 +40,13 @@ securityContext:
 
 ingress:
   hosts:
-    - host: main-check-client-qualifies-legal-aid-uat.cloud-platform.service.justice.gov.uk
+#    - host: main-check-client-qualifies-legal-aid-uat.cloud-platform.service.justice.gov.uk
+    - host: main-ccq-uat.cloud-platform.service.justice.gov.uk
       secret: false
   annotations:
-    external-dns.alpha.kubernetes.io/set-identifier: "check-client-qualifies-laa-estimate-eligibility-laa-estimate-financial-eligibility-for-legal-aid-uat-green"
-    external-dns.alpha.kubernetes.io/aws-weight: "100"
+    external-dns.alpha.kubernetes.io/set-identifier: "check-client-qualifies-laa-estimate-eligibility-laa-check-client-qualifies-uat-green"
+    # TODO: the weight is set to 0 for now but will need to be reverted to 100 at some point
+    external-dns.alpha.kubernetes.io/aws-weight: "0"
 
 notifications:
   errorMessageTemplateId: b8879191-e4bb-4f10-831a-7d9bd2b078f1
@@ -63,7 +65,6 @@ featureFlags:
   indexProduction: NOT_ENABLED
   maintenanceMode: NOT_ENABLED
   basicAuthentication: ENABLED
-  welshCw: ENABLED
 
 postgresql:
   enabled: true
@@ -108,4 +109,4 @@ google:
   oauthRedirectUri: https://main-check-client-qualifies-legal-aid-uat.cloud-platform.service.justice.gov.uk/auth/subdomain_redirect
 
 use_new_namespace:
-  enabled: false
+  enabled: true

--- a/helm_deploy/laa-estimate-eligibility/values/ccq-uat.yaml
+++ b/helm_deploy/laa-estimate-eligibility/values/ccq-uat.yaml
@@ -40,12 +40,14 @@ securityContext:
 
 ingress:
   hosts:
+# TODO: For now we are commenting out our existing host name and using a different one temporarily.
+# TODO: I understand that we will go back to using the existing host name, but for the purpose of testing, we are setting a new one now.
 #    - host: main-check-client-qualifies-legal-aid-uat.cloud-platform.service.justice.gov.uk
     - host: main-ccq-uat.cloud-platform.service.justice.gov.uk
       secret: false
   annotations:
     external-dns.alpha.kubernetes.io/set-identifier: "check-client-qualifies-laa-estimate-eligibility-laa-check-client-qualifies-uat-green"
-    # TODO: the weight is set to 0 for now but will need to be reverted to 100 at some point
+    # TODO: the weight is set to 0 for now but will need to be reverted to 100 at some point.
     external-dns.alpha.kubernetes.io/aws-weight: "0"
 
 notifications:
@@ -106,7 +108,7 @@ app:
 
 google:
   oauthClientId: 276075615370-ncqvmdi84jruv1jggfg4bu8nlvk1drj0.apps.googleusercontent.com
-  oauthRedirectUri: https://main-check-client-qualifies-legal-aid-uat.cloud-platform.service.justice.gov.uk/auth/subdomain_redirect
+  oauthRedirectUri: https://main-ccq-uat.cloud-platform.service.justice.gov.uk/auth/subdomain_redirect
 
 use_new_namespace:
   enabled: true

--- a/helm_deploy/laa-estimate-eligibility/values/production.yaml
+++ b/helm_deploy/laa-estimate-eligibility/values/production.yaml
@@ -83,3 +83,6 @@ app:
 google:
   oauthClientId: 276075615370-ncqvmdi84jruv1jggfg4bu8nlvk1drj0.apps.googleusercontent.com
   oauthRedirectUri: https://check-your-client-qualifies-for-legal-aid.service.gov.uk/auth/subdomain_redirect
+
+use_new_namespace:
+  enabled: false

--- a/helm_deploy/laa-estimate-eligibility/values/staging.yaml
+++ b/helm_deploy/laa-estimate-eligibility/values/staging.yaml
@@ -83,3 +83,6 @@ app:
 google:
   oauthClientId: 276075615370-ncqvmdi84jruv1jggfg4bu8nlvk1drj0.apps.googleusercontent.com
   oauthRedirectUri: https://staging.check-your-client-qualifies-for-legal-aid.service.gov.uk/auth/subdomain_redirect
+
+use_new_namespace:
+  enabled: false


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-1217)

## What changed and why

This PR gets dual deployments running to old and new UAT namespaces. Alongside changes here, changes are made in Circle CI Config and `kube-secrets`. These changes are detailed on the ticket. The same approach should be able to be used for staging and prod. 

This PR also makes changes to _env.tpl and the deploy script which should set the groundwork for dual running for other environments.

We are temporarily referring the the new namespace UAT environment as `ccq-uat` so that we can deploy successfully to a different URL.

## Guidance to review

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
