### PR TITLE
EL:1233: Display the full UAT URL, in CircleCI dashboard

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -3,7 +3,7 @@
 ENVIRONMENT=$1
 # Convert the branch name into a string that can be turned into a valid URL
   BRANCH_RELEASE_NAME=$(echo $CIRCLE_BRANCH | tr '[:upper:]' '[:lower:]' | sed 's:^\w*\/::' | tr -s ' _/[]().' '-' | cut -c1-18 | sed 's/-$//')
-
+  VIEWABLE_BRANCH_HOST_SUFFIX=$(echo $BRANCH_HOST_SUFFIX)
 
 deploy_branch() {
 # Set the deployment host, this will add the prefix of the branch name e.g el-257-deploy-with-circleci or just main
@@ -11,7 +11,7 @@ deploy_branch() {
 # Set the ingress name, needs release name, namespace and -green suffix
   IDENTIFIER="$BRANCH_RELEASE_NAME-laa-estimate-eligibility-$K8S_NAMESPACE-green"
   echo "Deploying CIRCLE_SHA1: $CIRCLE_SHA1 under release name: '$BRANCH_RELEASE_NAME'..."
-  echo "UAT URL is: $BRANCH_RELEASE_NAME-$BRANCH_HOST_SUFFIX.cloud-platform.service.justice.gov.uk"
+  echo "UAT URL is: $BRANCH_RELEASE_NAME-$VIEWABLE_BRANCH_HOST_SUFFIX.cloud-platform.service.justice.gov.uk"
 
   helm upgrade $BRANCH_RELEASE_NAME ./helm_deploy/laa-estimate-eligibility/. \
                 --install --wait \

--- a/bin/deploy
+++ b/bin/deploy
@@ -7,10 +7,11 @@ ENVIRONMENT=$1
 
 deploy_branch() {
 # Set the deployment host, this will add the prefix of the branch name e.g el-257-deploy-with-circleci or just main
-  RELEASE_HOST="$BRANCH_RELEASE_NAME-$HOST.cloud-platform.service.justice.gov.uk"
+  RELEASE_HOST="$BRANCH_RELEASE_NAME-$BRANCH_HOST_SUFFIX.cloud-platform.service.justice.gov.uk"
 # Set the ingress name, needs release name, namespace and -green suffix
   IDENTIFIER="$BRANCH_RELEASE_NAME-laa-estimate-eligibility-$K8S_NAMESPACE-green"
   echo "Deploying CIRCLE_SHA1: $CIRCLE_SHA1 under release name: '$BRANCH_RELEASE_NAME'..."
+  echo "UAT URL is: $BRANCH_RELEASE_NAME-$BRANCH_HOST_SUFFIX.cloud-platform.service.justice.gov.uk"
 
   helm upgrade $BRANCH_RELEASE_NAME ./helm_deploy/laa-estimate-eligibility/. \
                 --install --wait \

--- a/bin/deploy
+++ b/bin/deploy
@@ -6,20 +6,26 @@ ENVIRONMENT=$1
 
 
 deploy_branch() {
-# Set the deployment host, this will add the prefix of the branch name e.g el-257-deploy-with-circleci or just main
-  RELEASE_HOST="$BRANCH_RELEASE_NAME-$BRANCH_HOST_SUFFIX.cloud-platform.service.justice.gov.uk"
-# Set the ingress name, needs release name, namespace and -green suffix
-  IDENTIFIER="$BRANCH_RELEASE_NAME-laa-estimate-eligibility-$K8S_NAMESPACE-green"
-  echo "Deploying CIRCLE_SHA1: $CIRCLE_SHA1 under release name: '$BRANCH_RELEASE_NAME'..."
+  # The value of the environment variable or context will not be masked in the job output if 
+  # the value of the environment variable ($BRANCH_HOST_SUFFIX) is equal to one of true, True, false, or False
+  if [-z "${BRANCH_HOST_SUFFIX+x}" ]; then
+   echo "BRANCH_HOST_SUFFIX is unset"
+  else
+    # Set the deployment host, this will add the prefix of the branch name e.g el-257-deploy-with-circleci or just main
+      RELEASE_HOST="$BRANCH_RELEASE_NAME-$BRANCH_HOST_SUFFIX.cloud-platform.service.justice.gov.uk"
+    # Set the ingress name, needs release name, namespace and -green suffix
+      IDENTIFIER="$BRANCH_RELEASE_NAME-laa-estimate-eligibility-$K8S_NAMESPACE-green"
+      echo "Deploying CIRCLE_SHA1: $CIRCLE_SHA1 under release name: '$BRANCH_RELEASE_NAME'..."
 
-  helm upgrade $BRANCH_RELEASE_NAME ./helm_deploy/laa-estimate-eligibility/. \
-                --install --wait \
-                --namespace=${K8S_NAMESPACE} \
-                --values ./helm_deploy/laa-estimate-eligibility/values/$ENVIRONMENT.yaml \
-                --set image.repository="$ECR_ENDPOINT" \
-                --set image.tag="branch-$CIRCLE_SHA1" \
-                --set ingress.annotations."external-dns\.alpha\.kubernetes\.io/set-identifier"="$IDENTIFIER" \
-                --set ingress.hosts[0].host="$RELEASE_HOST"
+      helm upgrade $BRANCH_RELEASE_NAME ./helm_deploy/laa-estimate-eligibility/. \
+                    --install --wait \
+                    --namespace=${K8S_NAMESPACE} \
+                    --values ./helm_deploy/laa-estimate-eligibility/values/$ENVIRONMENT.yaml \
+                    --set image.repository="$ECR_ENDPOINT" \
+                    --set image.tag="branch-$CIRCLE_SHA1" \
+                    --set ingress.annotations."external-dns\.alpha\.kubernetes\.io/set-identifier"="$IDENTIFIER" \
+                    --set ingress.hosts[0].host="$RELEASE_HOST"
+  fi
 }
 
 deploy_main() {

--- a/bin/deploy
+++ b/bin/deploy
@@ -3,7 +3,7 @@
 ENVIRONMENT=$1
 # Convert the branch name into a string that can be turned into a valid URL
   BRANCH_RELEASE_NAME=$(echo $CIRCLE_BRANCH | tr '[:upper:]' '[:lower:]' | sed 's:^\w*\/::' | tr -s ' _/[]().' '-' | cut -c1-18 | sed 's/-$//')
-  VIEWABLE_BRANCH_HOST_SUFFIX=$(echo $BRANCH_HOST_SUFFIX)
+  VIEWABLE_BRANCH_HOST_SUFFIX=$(echo $BRANCH_HOST_SUFFIX | tr '[:upper:]' '[:lower:]')
 
 deploy_branch() {
 # Set the deployment host, this will add the prefix of the branch name e.g el-257-deploy-with-circleci or just main

--- a/bin/deploy
+++ b/bin/deploy
@@ -6,26 +6,20 @@ ENVIRONMENT=$1
 
 
 deploy_branch() {
-  # The value of the environment variable or context will not be masked in the job output if 
-  # the value of the environment variable ($BRANCH_HOST_SUFFIX) is equal to one of true, True, false, or False
-  if [-z "${BRANCH_HOST_SUFFIX+x}" ]; then
-   echo "BRANCH_HOST_SUFFIX is unset"
-  else
-    # Set the deployment host, this will add the prefix of the branch name e.g el-257-deploy-with-circleci or just main
-      RELEASE_HOST="$BRANCH_RELEASE_NAME-$BRANCH_HOST_SUFFIX.cloud-platform.service.justice.gov.uk"
-    # Set the ingress name, needs release name, namespace and -green suffix
-      IDENTIFIER="$BRANCH_RELEASE_NAME-laa-estimate-eligibility-$K8S_NAMESPACE-green"
-      echo "Deploying CIRCLE_SHA1: $CIRCLE_SHA1 under release name: '$BRANCH_RELEASE_NAME'..."
+# Set the deployment host, this will add the prefix of the branch name e.g el-257-deploy-with-circleci or just main
+  RELEASE_HOST="$BRANCH_RELEASE_NAME-$HOST.cloud-platform.service.justice.gov.uk"
+# Set the ingress name, needs release name, namespace and -green suffix
+  IDENTIFIER="$BRANCH_RELEASE_NAME-laa-estimate-eligibility-$K8S_NAMESPACE-green"
+  echo "Deploying CIRCLE_SHA1: $CIRCLE_SHA1 under release name: '$BRANCH_RELEASE_NAME'..."
 
-      helm upgrade $BRANCH_RELEASE_NAME ./helm_deploy/laa-estimate-eligibility/. \
-                    --install --wait \
-                    --namespace=${K8S_NAMESPACE} \
-                    --values ./helm_deploy/laa-estimate-eligibility/values/$ENVIRONMENT.yaml \
-                    --set image.repository="$ECR_ENDPOINT" \
-                    --set image.tag="branch-$CIRCLE_SHA1" \
-                    --set ingress.annotations."external-dns\.alpha\.kubernetes\.io/set-identifier"="$IDENTIFIER" \
-                    --set ingress.hosts[0].host="$RELEASE_HOST"
-  fi
+  helm upgrade $BRANCH_RELEASE_NAME ./helm_deploy/laa-estimate-eligibility/. \
+                --install --wait \
+                --namespace=${K8S_NAMESPACE} \
+                --values ./helm_deploy/laa-estimate-eligibility/values/$ENVIRONMENT.yaml \
+                --set image.repository="$ECR_ENDPOINT" \
+                --set image.tag="branch-$CIRCLE_SHA1" \
+                --set ingress.annotations."external-dns\.alpha\.kubernetes\.io/set-identifier"="$IDENTIFIER" \
+                --set ingress.hosts[0].host="$RELEASE_HOST"
 }
 
 deploy_main() {


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-1233)

## What changed and why

Updating this file `bin/deploy` in order to unhide `$BRANCH_HOST_SUFFIX` in CircleCI job output. 

> Secrets masking is applied to environment variables set within Project Settings or Contexts in the web app.
> 
> The value of the environment variable or context will not be masked in the job output if:
> 
> - the value of the environment variable is less than 4 characters
> - the value of the environment variable is equal to one of true, True, false, or False

## Guidance to review

- Used this [documentation ](https://circleci.com/docs/env-vars/#secrets-masking

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
