### PR TITLE
Spike: Why is main build step failing

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,3 +256,5 @@ Due to case-sensitivity in the integration between CircleCi and Jira, the Jira t
 For example:
 ❌ el-123-add-new-feature
 ✅ EL-123-add-new-feature
+
+FOO


### PR DESCRIPTION
The 'build and push' is failing because the pdftk-jar zip file is corrupt all of a sudden. Is that universal?