### PR TITLE
EL-1236: Proof of concept

### DIFF
--- a/app/controllers/check_answers_controller.rb
+++ b/app/controllers/check_answers_controller.rb
@@ -12,6 +12,7 @@ class CheckAnswersController < QuestionFlowController
         if next_step
           redirect_to helpers.check_step_path_from_step(next_step, assessment_code)
         else
+          # Promote the temporary copy of the answers to overwrite the original answers
           session[assessment_id] = session_data
           redirect_to check_answers_path(assessment_code:, anchor:)
         end
@@ -26,12 +27,15 @@ class CheckAnswersController < QuestionFlowController
 
 private
 
+  # While we're in a 'change answers loop', we want to be working with a temporary copy of the answers
+  # stored in a section of the session called 'pending'.
   def session_data
     data = super
-    if data[:pending]
+    if data[:pending] && !params[:begin_editing]
       data[:pending]
     else
       pending = data.dup
+      pending[:pending] = nil
       session[assessment_id][:pending] = pending
       pending
     end

--- a/app/controllers/check_answers_controller.rb
+++ b/app/controllers/check_answers_controller.rb
@@ -12,6 +12,7 @@ class CheckAnswersController < QuestionFlowController
         if next_step
           redirect_to helpers.check_step_path_from_step(next_step, assessment_code)
         else
+          session[assessment_id] = session_data
           redirect_to check_answers_path(assessment_code:, anchor:)
         end
       else
@@ -24,6 +25,17 @@ class CheckAnswersController < QuestionFlowController
   end
 
 private
+
+  def session_data
+    data = super
+    if data[:pending]
+      data[:pending]
+    else
+      pending = data.dup
+      session[assessment_id][:pending] = pending
+      pending
+    end
+  end
 
   def set_back_behaviour
     @back_buttons_invoke_browser_back_behaviour = true

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -3,8 +3,8 @@ module ApplicationHelper
     step_path(step_url_fragment: step_url_fragment_from_step(step), assessment_code:)
   end
 
-  def check_step_path_from_step(step, assessment_code, anchor: nil)
-    check_step_path(step_url_fragment: step_url_fragment_from_step(step), assessment_code:, anchor:)
+  def check_step_path_from_step(step, assessment_code, anchor: nil, begin_editing: nil)
+    check_step_path(step_url_fragment: step_url_fragment_from_step(step), assessment_code:, anchor:, begin_editing:)
   end
 
   def start_button_label(button_label)

--- a/app/views/checks/_check_answers_table.html.slim
+++ b/app/views/checks/_check_answers_table.html.slim
@@ -16,7 +16,7 @@
           - if change_links
             - anchor = "section-#{table.index + 1}" if table.index
             = link_to t("checks.check_answers.change"),
-                      check_step_path_from_step(table.screen.to_sym, params[:assessment_code], anchor:),
+                      check_step_path_from_step(table.screen.to_sym, params[:assessment_code], anchor:, begin_editing: true),
                       class: "change-link govuk-!-margin-top-1"
         .govuk-summary-card__content
           dl.govuk-summary-list


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-1236)

## What changed and why

When the user is in a change-answers loop, keep their new session data in a separate place until they complete the loop. That way if they 'back' out of it half way through the loop, their answers are still in a valid state.

## Guidance to review

<!-- anything useful to let the reviewer know? -->

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
