### PR TITLE
EL-1236: pending answers in change answer loops

### DIFF
--- a/app/controllers/change_answers_controller.rb
+++ b/app/controllers/change_answers_controller.rb
@@ -1,4 +1,4 @@
-class CheckAnswersController < QuestionFlowController
+class ChangeAnswersController < QuestionFlowController
   before_action :set_back_behaviour
 
   def update
@@ -31,13 +31,16 @@ private
   # stored in a section of the session called 'pending'.
   def session_data
     data = super
-    if data[:pending] && !params[:begin_editing]
-      data[:pending]
-    else
+
+    # Set up a fresh copy of the answers into the pending section if it's blank or we're
+    # starting a new loop
+    if !data[:pending] || params[:begin_editing]
       pending = data.dup
       pending[:pending] = nil
       session[assessment_id][:pending] = pending
       pending
+    else
+      data[:pending]
     end
   end
 

--- a/app/controllers/check_answers_controller.rb
+++ b/app/controllers/check_answers_controller.rb
@@ -12,6 +12,7 @@ class CheckAnswersController < QuestionFlowController
         if next_step
           redirect_to helpers.check_step_path_from_step(next_step, assessment_code)
         else
+          # Promote the temporary copy of the answers to overwrite the original answers
           session[assessment_id] = session_data
           redirect_to check_answers_path(assessment_code:, anchor:)
         end
@@ -26,12 +27,15 @@ class CheckAnswersController < QuestionFlowController
 
 private
 
+  # While we're in a 'change answers loop', we want to be working with a temporary copy of the answers
+  # stored in a section of the session called 'pending'.
   def session_data
     data = super
-    if data[:pending]
+    if data[:pending] && !params[:begin_editing]
       data[:pending]
     else
       pending = data.dup
+      pending[:pending] = nil
       session[assessment_id][:pending] = pending
       pending
     end

--- a/app/controllers/check_answers_controller.rb
+++ b/app/controllers/check_answers_controller.rb
@@ -12,6 +12,7 @@ class CheckAnswersController < QuestionFlowController
         if next_step
           redirect_to helpers.check_step_path_from_step(next_step, assessment_code)
         else
+          session[assessment_id] = session_data
           redirect_to check_answers_path(assessment_code:, anchor:)
         end
       else
@@ -24,6 +25,17 @@ class CheckAnswersController < QuestionFlowController
   end
 
 private
+
+  def session_data
+    data = super
+    if data[:pending]
+      data[:pending]
+    else
+      pending = data.dup
+      session[assessment_id][:pending] = pending
+      pending
+    end
+  end
 
   def set_back_behaviour
     @back_buttons_invoke_browser_back_behaviour = true

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -3,8 +3,8 @@ module ApplicationHelper
     step_path(step_url_fragment: step_url_fragment_from_step(step), assessment_code:)
   end
 
-  def check_step_path_from_step(step, assessment_code, anchor: nil)
-    check_step_path(step_url_fragment: step_url_fragment_from_step(step), assessment_code:, anchor:)
+  def check_step_path_from_step(step, assessment_code, anchor: nil, begin_editing: nil)
+    check_step_path(step_url_fragment: step_url_fragment_from_step(step), assessment_code:, anchor:, begin_editing:)
   end
 
   def start_button_label(button_label)

--- a/app/views/checks/_check_answers_table.html.slim
+++ b/app/views/checks/_check_answers_table.html.slim
@@ -16,7 +16,7 @@
           - if change_links
             - anchor = "section-#{table.index + 1}" if table.index
             = link_to t("checks.check_answers.change"),
-                      check_step_path_from_step(table.screen.to_sym, params[:assessment_code], anchor:),
+                      check_step_path_from_step(table.screen.to_sym, params[:assessment_code], anchor:, begin_editing: true),
                       class: "change-link govuk-!-margin-top-1"
         .govuk-summary-card__content
           dl.govuk-summary-list

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -58,6 +58,6 @@ Rails.application.routes.draw do
 
   get ":step_url_fragment/:assessment_code", to: "forms#show", as: :step
   put ":step_url_fragment/:assessment_code", to: "forms#update"
-  get ":step_url_fragment/:assessment_code/check", to: "check_answers#show", as: :check_step
-  put ":step_url_fragment/:assessment_code/check", to: "check_answers#update"
+  get ":step_url_fragment/:assessment_code/check", to: "change_answers#show", as: :check_step
+  put ":step_url_fragment/:assessment_code/check", to: "change_answers#update"
 end

--- a/spec/flows/change_answers_flow_spec.rb
+++ b/spec/flows/change_answers_flow_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
-RSpec.describe "Check answers", type: :feature do
-  it "prompts me to fill screens were previously skipped, skipping screens that were previously filled" do
+RSpec.describe "Change answers", type: :feature do
+  it "prompts me to fill screens were previously skipped, and saving my changes" do
     start_assessment
     fill_in_forms_until(:employment_status)
     fill_in_employment_status_screen(choice: "Unemployed")
@@ -13,6 +13,23 @@ RSpec.describe "Check answers", type: :feature do
     fill_in_employment_status_screen(choice: "Employed")
     fill_in_income_screen
     confirm_screen("check_answers")
+    expect(page).to have_content "What is your client's employment status?Employed or self-employed"
+  end
+
+  it "does not save my changes if I back out of them" do
+    start_assessment
+    fill_in_forms_until(:employment_status)
+    fill_in_employment_status_screen(choice: "Unemployed")
+    fill_in_forms_until(:check_answers)
+    confirm_screen("check_answers")
+    check_answers_url = current_path
+    within "#table-employment_status" do
+      click_on "Change"
+    end
+    fill_in_employment_status_screen(choice: "Employed")
+    visit check_answers_url # simulate clicking 'back' twice from employment details screen
+    confirm_screen("check_answers")
+    expect(page).to have_content "What is your client's employment status?Unemployed"
   end
 
   it "can handle a switch from passporting to not" do


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-1236)

## What changed and why

* Renamed CheckAnswersController to ChangeAnswersController (because "Check answers" is how we describe the check answers screen, and having it also mean where you go _from_ that screen was confusing me).
* In ChangeAnswersController, use temporary copy of the session data that we keep in a key called 'pending', and only override the main session data with the temporary copy when we complete a loop 

## Guidance to review

The session_data method in ChangeAnswersController overrides the default method in ApplicationController
## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
